### PR TITLE
try for card_fun

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # teal.reporter 0.1.0.9004
 
 * Added support for the `ElementaryTree` class in the `append_table` method of `ReportCard`.
-* Added the additional validation for the `card_fun` evaluation.
+* Added additional validation for the `card_fun` evaluation.
 
 # teal.reporter 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # teal.reporter 0.1.0.9004
 
 * Added support for the `ElementaryTree` class in the `append_table` method of `ReportCard`.
+* Added the additional validation for the `card_fun` evaluation.
 
 # teal.reporter 0.1.0
 

--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -127,7 +127,7 @@ add_card_button_srv <- function(id, reporter, card_fun) {
           msg <- paste0(
             "The card could not be added to the report. ",
             "Have the outputs for the report been created yet? If not please try again when they ",
-            "are ready. Otherwise contact your application developer" 
+            "are ready. Otherwise contact your application developer"
           )
           warning(msg)
           shiny::showNotification(

--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -125,8 +125,9 @@ add_card_button_srv <- function(id, reporter, card_fun) {
 
         if (inherits(card, "try-error")) {
           msg <- paste0(
-            "The card was not added successfully.",
-            "Possibly the card_fun is invalid or the shiny process is not ready to be catched."
+            "The card could not be added to the report. ",
+            "Have the outputs for the report been created yet? If not please try again when they ",
+            "are ready. Otherwise contact your application developer" 
           )
           warning(msg)
           shiny::showNotification(

--- a/tests/testthat/test-addCardModule.R
+++ b/tests/testthat/test-addCardModule.R
@@ -75,3 +75,19 @@ testthat::test_that("add_card_button_srv supports passing no default object to c
     }
   )
 })
+
+testthat::test_that("add_card_button_srv try the card_fun", {
+  card_fun <- function(card) {
+    stop("ERROR")
+  }
+
+  shiny::testServer(
+    add_card_button_srv,
+    args = list(reporter = Reporter$new(), card_fun = card_fun),
+    expr = {
+      session$setInputs(`add_report_card_button` = 0)
+      expect_warning(session$setInputs(`add_card_ok` = 0))
+    }
+  )
+})
+

--- a/tests/testthat/test-addCardModule.R
+++ b/tests/testthat/test-addCardModule.R
@@ -90,4 +90,3 @@ testthat::test_that("add_card_button_srv try the card_fun", {
     }
   )
 })
-


### PR DESCRIPTION
closes #86 

This should give the end user a proper message when the card_fun is not evaluated properly.
The modal is not closed automatically on purpose, we are sure sb read the message (bottom right).
