### PR TITLE
append_fs accepts a list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Decoupled the `metadata` and `content` in the `ReportCard`.
 * Added additional validation for the `card_fun` evaluation.
 * Added support for more arguments setup for a `card_fun` function in the `add_card_button_srv` module, specifically the `card_fun` could have any subset of the possible arguments.
-
+* Updated `append_fs` method in the `TealReportCard`, to accept a `list` object.
 
 # teal.reporter 0.1.0
 

--- a/R/TealReportCard.R
+++ b/R/TealReportCard.R
@@ -28,22 +28,18 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @description Appends the filter state list to the `content` and `metadata` of this `TealReportCard`.
     #'
     #' @param fs (`list`) a filter states.
-    #' @param format_fun (`function`) a function to format the filter states.
     #' @return invisibly self
     #' @examples
     #' card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
     #' card$get_content()[[1]]$get_content()
     #'
-    append_fs = function(fs, format_fun = function(fs) {
-                           yaml::as.yaml(fs, handlers = list(
-                             POSIXct = function(x) format(x, "%Y-%m-%d"),
-                             POSIXlt = function(x) format(x, "%Y-%m-%d"),
-                             Date = function(x) format(x, "%Y-%m-%d")
-                           ))
-                         }) {
+    append_fs = function(fs) {
       checkmate::assert_list(fs)
-      checkmate::assert_function(format_fun)
-      super$append_text(format_fun(fs), "verbatim")
+      super$append_text(yaml::as.yaml(fs, handlers = list(
+        POSIXct = function(x) format(x, "%Y-%m-%d"),
+        POSIXlt = function(x) format(x, "%Y-%m-%d"),
+        Date = function(x) format(x, "%Y-%m-%d")
+      )), "verbatim")
       super$append_metadata("FS", fs)
       invisible(self)
     },

--- a/R/TealReportCard.R
+++ b/R/TealReportCard.R
@@ -28,18 +28,22 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @description Appends the filter state list to the `content` and `metadata` of this `TealReportCard`.
     #'
     #' @param fs (`list`) a filter states.
+    #' @param format_fun (`list`) a function to format the filter states.
     #' @return invisibly self
     #' @examples
     #' card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
     #' card$get_content()[[1]]$get_content()
     #'
-    append_fs = function(fs) {
+    append_fs = function(fs, format_fun = function(fs) {
+                           yaml::as.yaml(fs, handlers = list(
+                             POSIXct = function(x) format(x, "%Y-%m-%d"),
+                             POSIXlt = function(x) format(x, "%Y-%m-%d"),
+                             Date = function(x) format(x, "%Y-%m-%d")
+                           ))
+                         }) {
       checkmate::assert_list(fs)
-      super$append_text(yaml::as.yaml(fs, handlers = list(
-        POSIXct = function(x) format(x, "%Y-%m-%d"),
-        POSIXlt = function(x) format(x, "%Y-%m-%d"),
-        Date = function(x) format(x, "%Y-%m-%d")
-      )), "verbatim")
+      checkmate::assert_function(format_fun)
+      super$append_text(format_fun(fs), "verbatim")
       super$append_metadata("FS", fs)
       invisible(self)
     },

--- a/R/TealReportCard.R
+++ b/R/TealReportCard.R
@@ -25,29 +25,26 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
       super$append_metadata("SRC", src)
       invisible(self)
     },
-    #' @description Appends the filter state list to the `content` meta data  of this `TealReportCard`.
+    #' @description Appends the filter state list to the `content` and `metadata` of this `TealReportCard`.
     #'
-    #' @param fs (`FilteredData`) with filter states.
+    #' @param fs (`list`) a filter states.
     #' @return invisibly self
     #' @examples
-    #' # Artificial FilteredData class
-    #' fs <- R6::R6Class("FilteredData",
-    #'   public = list(
-    #'     get_filter_state = function() list(a = 1, b = 3),
-    #'     get_formatted_filter_state = function() "a = 1 and b = 3"
-    #'   )
-    #' )
     #' fs_inst <- fs$new()
-    #' card <- TealReportCard$new()$append_fs(fs_inst)
+    #' card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
     #' card$get_content()[[1]]$get_content()
     #'
     append_fs = function(fs) {
-      checkmate::assert_class(fs, "FilteredData")
-      super$append_text(fs$get_formatted_filter_state(), "verbatim")
-      super$append_metadata("FS", fs$get_filter_state())
+      checkmate::assert_list(fs)
+      super$append_text(yaml::as.yaml(fs, handlers = list(
+        POSIXct = function(x) format(x, "%Y-%m-%d"),
+        POSIXlt = function(x) format(x, "%Y-%m-%d"),
+        Date = function(x) format(x, "%Y-%m-%d")
+      )), "verbatim")
+      super$append_metadata("FS", fs)
       invisible(self)
     },
-    #' @description Appends the encodings list to the `content` meta data of this `TealReportCard`.
+    #' @description Appends the encodings list to the `content` and `metadata` of this `TealReportCard`.
     #'
     #' @param encodings (`list`) list of encodings selections of the teal app.
     #' @return invisibly self
@@ -57,7 +54,11 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     #'
     append_encodings = function(encodings) {
       checkmate::assert_list(encodings)
-      super$append_text(yaml::as.yaml(encodings), "verbatim")
+      super$append_text(yaml::as.yaml(encodings, handlers = list(
+        POSIXct = function(x) format(x, "%Y-%m-%d"),
+        POSIXlt = function(x) format(x, "%Y-%m-%d"),
+        Date = function(x) format(x, "%Y-%m-%d")
+      )), "verbatim")
       super$append_metadata("Encodings", encodings)
       invisible(self)
     }

--- a/R/TealReportCard.R
+++ b/R/TealReportCard.R
@@ -27,7 +27,7 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     },
     #' @description Appends the filter state list to the `content` and `metadata` of this `TealReportCard`.
     #'
-    #' @param fs (`list`) a filter states.
+    #' @param fs (`list`) of filter states.
     #' @return invisibly self
     #' @examples
     #' card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))

--- a/R/TealReportCard.R
+++ b/R/TealReportCard.R
@@ -28,7 +28,7 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @description Appends the filter state list to the `content` and `metadata` of this `TealReportCard`.
     #'
     #' @param fs (`list`) a filter states.
-    #' @param format_fun (`list`) a function to format the filter states.
+    #' @param format_fun (`function`) a function to format the filter states.
     #' @return invisibly self
     #' @examples
     #' card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))

--- a/R/TealReportCard.R
+++ b/R/TealReportCard.R
@@ -30,7 +30,6 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @param fs (`list`) a filter states.
     #' @return invisibly self
     #' @examples
-    #' fs_inst <- fs$new()
     #' card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
     #' card$get_content()[[1]]$get_content()
     #'
@@ -49,7 +48,7 @@ TealReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @param encodings (`list`) list of encodings selections of the teal app.
     #' @return invisibly self
     #' @examples
-    #' card <- TealReportCard$new()$append_encodings(list("variable 1 is X"))
+    #' card <- TealReportCard$new()$append_encodings(list(variable1 = "X"))
     #' card$get_content()[[1]]$get_content()
     #'
     append_encodings = function(encodings) {

--- a/man/TealReportCard.Rd
+++ b/man/TealReportCard.Rd
@@ -25,7 +25,6 @@ card$get_content()[[1]]$get_content()
 ## Method `TealReportCard$append_fs`
 ## ------------------------------------------------
 
-fs_inst <- fs$new()
 card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
 card$get_content()[[1]]$get_content()
 
@@ -34,7 +33,7 @@ card$get_content()[[1]]$get_content()
 ## Method `TealReportCard$append_encodings`
 ## ------------------------------------------------
 
-card <- TealReportCard$new()$append_encodings(list("variable 1 is X"))
+card <- TealReportCard$new()$append_encodings(list(variable1 = "X"))
 card$get_content()[[1]]$get_content()
 
 }
@@ -121,8 +120,7 @@ invisibly self
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
-\preformatted{fs_inst <- fs$new()
-card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
+\preformatted{card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
 card$get_content()[[1]]$get_content()
 
 }
@@ -152,7 +150,7 @@ invisibly self
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
-\preformatted{card <- TealReportCard$new()$append_encodings(list("variable 1 is X"))
+\preformatted{card <- TealReportCard$new()$append_encodings(list(variable1 = "X"))
 card$get_content()[[1]]$get_content()
 
 }

--- a/man/TealReportCard.Rd
+++ b/man/TealReportCard.Rd
@@ -105,22 +105,13 @@ card$get_content()[[1]]$get_content()
 \subsection{Method \code{append_fs()}}{
 Appends the filter state list to the \code{content} and \code{metadata} of this \code{TealReportCard}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealReportCard$append_fs(
-  fs,
-  format_fun = function(fs) {
-     yaml::as.yaml(fs, handlers = list(POSIXct =
-    function(x) format(x, "\%Y-\%m-\%d"), POSIXlt = function(x) format(x, "\%Y-\%m-\%d"),
-    Date = function(x) format(x, "\%Y-\%m-\%d")))
- }
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TealReportCard$append_fs(fs)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{fs}}{(\code{list}) a filter states.}
-
-\item{\code{format_fun}}{(\code{function}) a function to format the filter states.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TealReportCard.Rd
+++ b/man/TealReportCard.Rd
@@ -105,13 +105,22 @@ card$get_content()[[1]]$get_content()
 \subsection{Method \code{append_fs()}}{
 Appends the filter state list to the \code{content} and \code{metadata} of this \code{TealReportCard}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealReportCard$append_fs(fs)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TealReportCard$append_fs(
+  fs,
+  format_fun = function(fs) {
+     yaml::as.yaml(fs, handlers = list(POSIXct =
+    function(x) format(x, "\%Y-\%m-\%d"), POSIXlt = function(x) format(x, "\%Y-\%m-\%d"),
+    Date = function(x) format(x, "\%Y-\%m-\%d")))
+ }
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{fs}}{(\code{list}) a filter states.}
+
+\item{\code{format_fun}}{(\code{function}) a function to format the filter states.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TealReportCard.Rd
+++ b/man/TealReportCard.Rd
@@ -111,7 +111,7 @@ Appends the filter state list to the \code{content} and \code{metadata} of this 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{fs}}{(\code{list}) a filter states.}
+\item{\code{fs}}{(\code{list}) of filter states.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TealReportCard.Rd
+++ b/man/TealReportCard.Rd
@@ -25,15 +25,8 @@ card$get_content()[[1]]$get_content()
 ## Method `TealReportCard$append_fs`
 ## ------------------------------------------------
 
-# Artificial FilteredData class
-fs <- R6::R6Class("FilteredData",
-  public = list(
-    get_filter_state = function() list(a = 1, b = 3),
-    get_formatted_filter_state = function() "a = 1 and b = 3"
-  )
-)
 fs_inst <- fs$new()
-card <- TealReportCard$new()$append_fs(fs_inst)
+card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
 card$get_content()[[1]]$get_content()
 
 
@@ -111,7 +104,7 @@ card$get_content()[[1]]$get_content()
 \if{html}{\out{<a id="method-TealReportCard-append_fs"></a>}}
 \if{latex}{\out{\hypertarget{method-TealReportCard-append_fs}{}}}
 \subsection{Method \code{append_fs()}}{
-Appends the filter state list to the \code{content} meta data  of this \code{TealReportCard}.
+Appends the filter state list to the \code{content} and \code{metadata} of this \code{TealReportCard}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TealReportCard$append_fs(fs)}\if{html}{\out{</div>}}
 }
@@ -119,7 +112,7 @@ Appends the filter state list to the \code{content} meta data  of this \code{Tea
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{fs}}{(\code{FilteredData}) with filter states.}
+\item{\code{fs}}{(\code{list}) a filter states.}
 }
 \if{html}{\out{</div>}}
 }
@@ -128,15 +121,8 @@ invisibly self
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
-\preformatted{# Artificial FilteredData class
-fs <- R6::R6Class("FilteredData",
-  public = list(
-    get_filter_state = function() list(a = 1, b = 3),
-    get_formatted_filter_state = function() "a = 1 and b = 3"
-  )
-)
-fs_inst <- fs$new()
-card <- TealReportCard$new()$append_fs(fs_inst)
+\preformatted{fs_inst <- fs$new()
+card <- TealReportCard$new()$append_fs(list(a = 1, b = 2))
 card$get_content()[[1]]$get_content()
 
 }
@@ -149,7 +135,7 @@ card$get_content()[[1]]$get_content()
 \if{html}{\out{<a id="method-TealReportCard-append_encodings"></a>}}
 \if{latex}{\out{\hypertarget{method-TealReportCard-append_encodings}{}}}
 \subsection{Method \code{append_encodings()}}{
-Appends the encodings list to the \code{content} meta data of this \code{TealReportCard}.
+Appends the encodings list to the \code{content} and \code{metadata} of this \code{TealReportCard}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TealReportCard$append_encodings(encodings)}\if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-TealReportCard.R
+++ b/tests/testthat/test-TealReportCard.R
@@ -41,31 +41,23 @@ testthat::test_that("TealReportCard$append_src returns self", {
 
 testthat::test_that("TealReportCard$append_encodings accepts list of character", {
   card <- TealReportCard$new()
-  testthat::expect_error(card$append_encodings(list("test")), regexp = NA)
+  testthat::expect_error(card$append_encodings(list(a = "test")), regexp = NA)
 })
 
 testthat::test_that("TealReportCard$append_encodings returns self", {
   card <- TealReportCard$new()
-  testthat::expect_identical(card$append_encodings(list("test_encodings")), card)
+  testthat::expect_identical(card$append_encodings(list(a = "test_encodings")), card)
 })
-
-fs <- R6::R6Class("FilteredData",
-  public = list(
-    get_filter_state = function() list(a = 1, b = 3),
-    get_formatted_filter_state = function() "TEST"
-  )
-)
-fs_inst <- fs$new()
 
 testthat::test_that("TealReportCard$append_fs accepts only a FilteredData", {
   card <- TealReportCard$new()
-  testthat::expect_error(card$append_fs(list(a = 1)),
-    regexp = "Must inherit from class 'FilteredData'"
+  testthat::expect_error(card$append_fs(c(a = 1, b = 2)),
+    regexp = "Assertion on 'fs' failed: Must be of type 'list', not 'double'."
   )
-  testthat::expect_error(card$append_fs(fs_inst), regexp = NA)
+  testthat::expect_error(card$append_fs(list(a = 1, b = 2)), regexp = NA)
 })
 
 testthat::test_that("TealReportCard$append_fs returns self", {
   card <- TealReportCard$new()
-  testthat::expect_identical(card$append_fs(fs_inst), card)
+  testthat::expect_identical(card$append_fs(list(a = 1, b = 2)), card)
 })


### PR DESCRIPTION
closes #96 

`append_fs` in the `TealReportCard` accept a regular `list` now.

The drawback is that under yaml::as.yaml ranges are not so clear because of lack of the from/to words. Another thing is a longer printout.

Because of this too long printout we should think about sth custom.