### PR TITLE
append_plot - grid::grid.draw for trellis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Decoupled the `metadata` and `content` in the `ReportCard`.
 * Added additional validation for the `card_fun` evaluation.
 * Added support for more arguments setup for a `card_fun` function in the `add_card_button_srv` module, specifically the `card_fun` could have any subset of the possible arguments.
-* Fixed how `trellis` plots are catched by the `append_plot` method in the `ReportCard`.
+* Fixed how `trellis` plots are catched by the `set_content` method in the `PictureBlock`.
 
 # teal.reporter 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Decoupled the `metadata` and `content` in the `ReportCard`.
 * Added additional validation for the `card_fun` evaluation.
 * Added support for more arguments setup for a `card_fun` function in the `add_card_button_srv` module, specifically the `card_fun` could have any subset of the possible arguments.
-
+* Fixed how `trellis` plots are catched by the `append_plot` method in the `ReportCard`.
 
 # teal.reporter 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Decoupled the `metadata` and `content` in the `ReportCard`.
 * Added additional validation for the `card_fun` evaluation.
 * Added support for more arguments setup for a `card_fun` function in the `add_card_button_srv` module, specifically the `card_fun` could have any subset of the possible arguments.
-* Fixed how `trellis` plots are catched by the `set_content` method in the `PictureBlock`.
+* Fixed how `trellis` plots are catch by the `set_content` method in the `PictureBlock`.
 
 # teal.reporter 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Decoupled the `metadata` and `content` in the `ReportCard`.
 * Added additional validation for the `card_fun` evaluation.
 * Added support for more arguments setup for a `card_fun` function in the `add_card_button_srv` module, specifically the `card_fun` could have any subset of the possible arguments.
-* Fixed how `trellis` plots are catch by the `set_content` method in the `PictureBlock`.
+* Fixed how `trellis` plots are catched by the `set_content` method in the `PictureBlock`.
 
 # teal.reporter 0.1.0
 

--- a/R/PictureBlock.R
+++ b/R/PictureBlock.R
@@ -44,7 +44,7 @@ PictureBlock <- R6::R6Class( # nolint: object_name_linter.
             print(content)
           } else if (inherits(content, "trellis")) {
             grid::grid.newpage()
-            grid::grid.grabExpr(print(content), warn = 0, wrap.grobs = TRUE)
+            grid::grid.draw(grid::grid.grabExpr(print(content), warn = 0, wrap.grobs = TRUE))
           }
           super$set_content(path)
         },

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,2 +1,3 @@
 Github
+catched
 cloneable


### PR DESCRIPTION
closes #98 

Add `grid::grid.draw` for `trellis` objects in the `append_plot` method.