### PR TITLE
try render and check for pdflatex

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Suggests:
     lattice,
     png,
     rtables (>= 0.5.1),
-    testthat
+    testthat,
+    tinytex
 VignetteBuilder:
     knitr
 RdMacros:

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -146,12 +146,13 @@ report_render_and_compress <- function(reporter, input_list, file = tempdir()) {
   checkmate::assert_string(file)
 
   if (identical("pdf_document", input_list$output) &&
-      inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
-    warning("pdflatex is not available so the pdf_document could not be rendered.")
+      inherits(try(system2("pdflatex --version", stdout = TRUE), silent = TRUE), "try-error")) {
     shiny::showNotification(
-      ui = "pdflatex is not available so the pdf_document could not be rendered.",
-      type = "warning"
+      ui = "pdflatex is not available so the pdf_document could not be rendered. Please use other output type.",
+      action = "Please contact app developer",
+      type = "error"
     )
+    stop("pdflatex is not available so the pdf_document could not be rendered.")
   }
 
   yaml_header <- as_yaml_auto(input_list)

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -146,7 +146,7 @@ report_render_and_compress <- function(reporter, input_list, file = tempdir()) {
   checkmate::assert_string(file)
 
   if (identical("pdf_document", input_list$output) &&
-    inherits(try(system2("pdflatex --version", stdout = TRUE), silent = TRUE), "try-error")) {
+    inherits(try(system2("pdflatex", "--version", stdout = TRUE), silent = TRUE), "try-error")) {
     shiny::showNotification(
       ui = "pdflatex is not available so the pdf_document could not be rendered. Please use other output type.",
       action = "Please contact app developer",

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -146,7 +146,7 @@ report_render_and_compress <- function(reporter, input_list, file = tempdir()) {
   checkmate::assert_string(file)
 
   if (identical("pdf_document", input_list$output) &&
-      inherits(try(system2("pdflatex --version", stdout = TRUE), silent = TRUE), "try-error")) {
+    inherits(try(system2("pdflatex --version", stdout = TRUE), silent = TRUE), "try-error")) {
     shiny::showNotification(
       ui = "pdflatex is not available so the pdf_document could not be rendered. Please use other output type.",
       action = "Please contact app developer",

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -54,7 +54,11 @@ download_report_button_srv <- function(id,
   checkmate::assert_true(all(c("author", "title", "date", "output") %in% names(rmd_yaml_args)))
 
   if ("pdf_document" %in% rmd_output && inherits(try(system("pdflatex --version")), "try-error")) {
-    warning("pdflatex is not available so the pdf_document output is hidden from use.")
+    warning("pdflatex is not available so the pdf_document output is hidden for use.")
+    shiny::showNotification(
+      ui = "pdflatex is not available so the pdf_document output is hidden for use.",
+      type = "warning"
+    )
     rmd_output <- setdiff(rmd_output, "pdf_document")
   }
 

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -53,7 +53,7 @@ download_report_button_srv <- function(id,
   checkmate::assert_list(rmd_yaml_args, names = "named")
   checkmate::assert_true(all(c("author", "title", "date", "output") %in% names(rmd_yaml_args)))
 
-  if ("pdf_document" %in% rmd_output && inherits(try(system("pdflatex --version")), "try-error")) {
+  if ("pdf_document" %in% rmd_output && inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
     warning("pdflatex is not available so the pdf_document output is hidden for use.")
     shiny::showNotification(
       ui = "pdflatex is not available so the pdf_document output is hidden for use.",

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -17,15 +17,7 @@ reporter_previewer_ui <- function(id, rmd_output = c(
                                     date = as.character(Sys.Date()), output = "html_document"
                                   )) {
   checkmate::assert_list(rmd_yaml_args)
-  if ("pdf_document" %in% rmd_output && inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
-    warning("pdflatex is not available so the pdf_document output is hidden for use.")
-    shiny::showNotification(
-      ui = "pdflatex is not available so the pdf_document output is hidden for use.",
-      type = "warning"
-    )
-    rmd_output <- setdiff(rmd_output, "pdf_document")
-  }
-  
+
   ns <- shiny::NS(id)
   encoding <- shiny::tagList(
     shiny::tags$h3("Download the Report"),
@@ -87,7 +79,7 @@ reporter_previewer_srv <- function(id, reporter, rmd_yaml_args = list(
                                    )) {
   checkmate::assert_class(reporter, "Reporter")
   checkmate::assert_list(rmd_yaml_args)
-  
+
   shiny::moduleServer(
     id,
     function(input, output, session) {
@@ -153,7 +145,14 @@ reporter_previewer_srv <- function(id, reporter, rmd_yaml_args = list(
           shiny::showNotification("Rendering and Downloading the document.")
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
-          report_render_and_compress(reporter, input_list, file)
+          res <- try(report_render_and_compress(reporter, input_list, file))
+          if (inherits(res, "try-error")) {
+            shiny::showNotification(
+              ui = "Report failed to be generated.",
+              action = "Please contact app developer",
+              type = "error"
+            )
+          }
         },
         contentType = "application/zip"
       )

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -16,7 +16,6 @@ reporter_previewer_ui <- function(id, rmd_output = c(
                                     author = "NEST", title = "Report",
                                     date = as.character(Sys.Date()), output = "html_document"
                                   )) {
-  checkmate::assert_list(rmd_output)
   checkmate::assert_list(rmd_yaml_args)
   if ("pdf_document" %in% rmd_output && inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
     warning("pdflatex is not available so the pdf_document output is hidden for use.")

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -16,6 +16,17 @@ reporter_previewer_ui <- function(id, rmd_output = c(
                                     author = "NEST", title = "Report",
                                     date = as.character(Sys.Date()), output = "html_document"
                                   )) {
+  checkmate::assert_list(rmd_output)
+  checkmate::assert_list(rmd_yaml_args)
+  if ("pdf_document" %in% rmd_output && inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
+    warning("pdflatex is not available so the pdf_document output is hidden for use.")
+    shiny::showNotification(
+      ui = "pdflatex is not available so the pdf_document output is hidden for use.",
+      type = "warning"
+    )
+    rmd_output <- setdiff(rmd_output, "pdf_document")
+  }
+  
   ns <- shiny::NS(id)
   encoding <- shiny::tagList(
     shiny::tags$h3("Download the Report"),
@@ -77,15 +88,6 @@ reporter_previewer_srv <- function(id, reporter, rmd_yaml_args = list(
                                    )) {
   checkmate::assert_class(reporter, "Reporter")
   checkmate::assert_list(rmd_yaml_args)
-  
-  if ("pdf_document" %in% rmd_output && inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
-    warning("pdflatex is not available so the pdf_document output is hidden for use.")
-    shiny::showNotification(
-      ui = "pdflatex is not available so the pdf_document output is hidden for use.",
-      type = "warning"
-    )
-    rmd_output <- setdiff(rmd_output, "pdf_document")
-  }
   
   shiny::moduleServer(
     id,

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -145,14 +145,7 @@ reporter_previewer_srv <- function(id, reporter, rmd_yaml_args = list(
           shiny::showNotification("Rendering and Downloading the document.")
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
-          res <- try(report_render_and_compress(reporter, input_list, file))
-          if (inherits(res, "try-error")) {
-            shiny::showNotification(
-              ui = "Report failed to be generated.",
-              action = "Please contact app developer",
-              type = "error"
-            )
-          }
+          report_render_and_compress(reporter, input_list, file)
         },
         contentType = "application/zip"
       )

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -76,6 +76,17 @@ reporter_previewer_srv <- function(id, reporter, rmd_yaml_args = list(
                                      date = as.character(Sys.Date()), output = "html_document"
                                    )) {
   checkmate::assert_class(reporter, "Reporter")
+  checkmate::assert_list(rmd_yaml_args)
+  
+  if ("pdf_document" %in% rmd_output && inherits(try(system2("pdflatex --version", stdout = TRUE)), "try-error")) {
+    warning("pdflatex is not available so the pdf_document output is hidden for use.")
+    shiny::showNotification(
+      ui = "pdflatex is not available so the pdf_document output is hidden for use.",
+      type = "warning"
+    )
+    rmd_output <- setdiff(rmd_output, "pdf_document")
+  }
+  
   shiny::moduleServer(
     id,
     function(input, output, session) {

--- a/R/TableBlock.R
+++ b/R/TableBlock.R
@@ -35,7 +35,7 @@ TableBlock <- R6::R6Class( # nolint: object_name_linter.
     }
   ),
   private = list(
-    supported_tables = c("data.frame", "rtables", "TableTree", "ElementaryTable")
+    supported_tables = c("data.frame", "rtables", "TableTree", "ElementaryTable", "knitr_kable")
   ),
   lock_objects = TRUE,
   lock_class = TRUE

--- a/R/TableBlock.R
+++ b/R/TableBlock.R
@@ -35,7 +35,7 @@ TableBlock <- R6::R6Class( # nolint: object_name_linter.
     }
   ),
   private = list(
-    supported_tables = c("data.frame", "rtables", "TableTree", "ElementaryTable", "knitr_kable")
+    supported_tables = c("data.frame", "rtables", "TableTree", "ElementaryTable")
   ),
   lock_objects = TRUE,
   lock_class = TRUE

--- a/man/download_report_button_srv.Rd
+++ b/man/download_report_button_srv.Rd
@@ -19,7 +19,8 @@ download_report_button_srv(
 \item{reporter}{\code{\link{Reporter}} instance.}
 
 \item{rmd_output}{\code{character} vector with \code{rmarkdown} output types,
-by default all possible \code{c("pdf_document", "html_document", "powerpoint_presentation", "word_document")}.}
+by default all possible \code{c("pdf_document", "html_document", "powerpoint_presentation", "word_document")}.
+\code{pdflatex} has to be installed to use the \code{"pdf_document"} output.}
 
 \item{rmd_yaml_args}{\verb{named list} vector with \code{Rmd} \code{yaml} header fields and their default values.
 Default \code{list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document")}.


### PR DESCRIPTION
closes #89 

- Add a validation if the pdflatex is installed, if not raise an error.
- try call around the render call.
- rm sprintf where not needed.

tested with `podman run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio` as it not contains `pdflatex` by default. 
