### PR TITLE
Revert "staged deps for teal.osprey"

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -15,9 +15,6 @@ downstream_repos:
   insightsengineering/teal.modules.general:
     repo: insightsengineering/teal.modules.general
     host: https://github.com
-  insightsengineering/teal.osprey:
-    repo: insightsengineering/teal.osprey
-    host: https://github.com
 upstream_repos:
   Roche/rtables:
     repo: Roche/rtables


### PR DESCRIPTION
Reverts insightsengineering/teal.reporter#114 as we don't want this in until the osprey one is ready