### PR TITLE
Update Renderer.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 
 ### Bug fixes
 * Fixed how `trellis` plots are catched by the `set_content` method in the `PictureBlock`.
+* Fixed the plot height in a report document.
 
 ### Miscellaneous
 * Added `to_list` and `from_list` methods to all content related classes.

--- a/R/Renderer.R
+++ b/R/Renderer.R
@@ -149,7 +149,7 @@ Renderer <- R6::R6Class( # nolint: object_name_linter.
       basename_pic <- basename(block$get_content())
       file.copy(block$get_content(), file.path(private$output_dir, basename_pic))
       title <- block$get_title()
-      sprintf("![%s](%s){width=%s, height=%s}", title, basename_pic, block$get_dim()[1], block$get_dim()[2]) # nolint
+      sprintf("![%s](%s){width=%s height=%s}", title, basename_pic, block$get_dim()[1], block$get_dim()[2]) # nolint
     },
     tableBlock2md = function(block) {
       basename_table <- basename(block$get_content())


### PR DESCRIPTION
closes #147 

Not the height of the plot will be taken in to account too when it is rendered.

Please render any html document and check the img tag that now it contains both height and width. 

![image](https://user-images.githubusercontent.com/10676545/194837782-463ae59d-024e-45a6-987a-7bb20cf7489f.png)
