### PR TITLE
disable the add card button when clicked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Updated `append_encodings`, `append_src` and `append_fs` to automatically add titles.
 * Updated vignettes and README content.
 * Made the document type names more user friendly when downloading the report.
+* Improved the add reporter card button to be disabled when clicked.
 
 ### Bug fixes
 * Fixed how `trellis` plots are catched by the `set_content` method in the `PictureBlock`.

--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -8,9 +8,27 @@
 #' @export
 add_card_button_ui <- function(id) {
   ns <- shiny::NS(id)
+
   shiny::tagList(
     shiny::singleton(
       shiny::tags$head(shiny::includeCSS(system.file("css/custom.css", package = "teal.reporter")))
+    ),
+    shiny::singleton(
+      shiny::tags$head(
+        shiny::tags$script(
+          shiny::HTML(
+            sprintf(
+              '
+              $(document).ready(function(event) {
+                $("body").on("click", "#%s", function() {
+                  $(this).addClass("disabled");
+                })
+              })',
+              ns("add_card_ok")
+            )
+          )
+        )
+      )
     ),
     shiny::tags$button(
       id = ns("add_report_card_button"),
@@ -77,7 +95,7 @@ add_card_button_srv <- function(id, reporter, card_fun) {
             placeholder = "Add a comment here...",
             width = "100%"
           ),
-          footer = shiny::tagList(
+          footer = shiny::div(
             shiny::tags$button(
               type = "button",
               class = "btn btn-danger",

--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -9,6 +9,9 @@
 add_card_button_ui <- function(id) {
   ns <- shiny::NS(id)
 
+  # Buttons
+  # with custom css and
+  # js code to disable the add card button when clicked to prevent multi-clicks
   shiny::tagList(
     shiny::singleton(
       shiny::tags$head(shiny::includeCSS(system.file("css/custom.css", package = "teal.reporter")))
@@ -120,6 +123,8 @@ add_card_button_srv <- function(id, reporter, card_fun) {
         shiny::showModal(add_modal())
       })
 
+      # the button is disabled when clicked to prevent multi-clicks
+      # please check the ui part for more information
       shiny::observeEvent(input$add_card_ok, {
         card_fun_args_nams <- names(formals(card_fun))
         has_card_arg <- "card" %in% card_fun_args_nams

--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -9,8 +9,7 @@
 add_card_button_ui <- function(id) {
   ns <- shiny::NS(id)
 
-  # Buttons
-  # with custom css and
+  # Buttons with custom css and
   # js code to disable the add card button when clicked to prevent multi-clicks
   shiny::tagList(
     shiny::singleton(
@@ -123,7 +122,7 @@ add_card_button_srv <- function(id, reporter, card_fun) {
         shiny::showModal(add_modal())
       })
 
-      # the button is disabled when clicked to prevent multi-clicks
+      # the add card button is disabled when clicked to prevent multi-clicks
       # please check the ui part for more information
       shiny::observeEvent(input$add_card_ok, {
         card_fun_args_nams <- names(formals(card_fun))

--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -52,13 +52,6 @@
   padding: 0.25rem;
 }
 
-div.disabled {
-  pointer-events: none;
-  /* for "disabled" effect */
-  opacity: 0.5;
-  background: #CCC;
-}
-
 /* dynamic labels after icons */
 
 .simple_reporter_container {

--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -52,6 +52,13 @@
   padding: 0.25rem;
 }
 
+div.disabled {
+  pointer-events: none;
+  /* for "disabled" effect */
+  opacity: 0.5;
+  background: #CCC;
+}
+
 /* dynamic labels after icons */
 
 .simple_reporter_container {


### PR DESCRIPTION
closes https://github.com/insightsengineering/coredev-tasks/issues/400

Fix the problem of slow computation and possible multi added cards for multi clicks.

Please add Sys.sleep(10) to card_fun during test to simulate slow evaluation, e.g. in the previewer example app.