### PR TITLE
Enable multiline comments in report previewer and focus on 'add card' comment box

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New features
 
-* Updated the AddCardModule comment input to have an active cursor when adding a card.
+* Updated the `AddCardModule` comment input to have an active cursor when adding a card.
 * Updated report previewer to support preview of multiline comment.
 
 # teal.reporter 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ### New features
 
 * Updated the AddCardModule comment input to have an active cursor when adding a card.
-* Updated report previewer to allow multiline comment.
+* Updated report previewer to support preview of multiline comment.
 
 # teal.reporter 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New features
 
-* Updated the comment block to have an active cursor when adding a card.
+* Updated the AddCardModule comment input to have an active cursor when adding a card.
 * Updated report previewer to allow multiline comment.
 
 # teal.reporter 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ### New features
 
 * Updated the comment block to have an active cursor when adding a card.
-* Updated report previewer to render markdown as in the downloaded document.
+* Updated report previewer to allow multiline comment.
 
 # teal.reporter 0.1.1
 

--- a/tests/testthat/test-PreviewerReportModule.R
+++ b/tests/testthat/test-PreviewerReportModule.R
@@ -124,21 +124,4 @@ testthat::test_that("reporter_previewer_ui - returns a tagList", {
   )
 })
 
-testthat::test_that("render_text_block_preview - markdown renders to html fragment", {
-  block <- TextBlock$new()
 
-  block$set_content(
-    "
-  this is a multiline comment
-  line 2
-  line 3
-  "
-  )
-
-  block_html <- block_to_html(block)
-
-  testthat::expect_equal(
-    as.character(block_html),
-    "<pre>\n  this is a multiline comment\n  line 2\n  line 3\n  </pre>"
-  )
-})

--- a/tests/testthat/test-PreviewerReportModule.R
+++ b/tests/testthat/test-PreviewerReportModule.R
@@ -125,7 +125,6 @@ testthat::test_that("reporter_previewer_ui - returns a tagList", {
 })
 
 testthat::test_that("render_text_block_preview - markdown renders to html fragment", {
-
   block <- TextBlock$new()
 
   block$set_content(

--- a/tests/testthat/test-PreviewerReportModule.R
+++ b/tests/testthat/test-PreviewerReportModule.R
@@ -123,5 +123,3 @@ testthat::test_that("reporter_previewer_ui - returns a tagList", {
     inherits(reporter_previewer_ui("sth"), c("shiny.tag"))
   )
 })
-
-


### PR DESCRIPTION
This PR enables markdown rendering in the report previewer. Users can use markdown in report card comment boxes and it will display in the previewer. Note that markdown in comment boxes already renders correctly in the downloaded report. The change here ensures rendering in the previewer within an app.

Also sets the cursor to focus in the comment box when the add report card button is clicked.

Note the first comment in the issues shows a multiline comment not rendering correctly. However the syntax is off because for markdown, there needs to be a blank line between each comment line.

There are no tests for this PR because

1. for the cursor focus, there isn't really an easy way to test this.
2. testing report previewer rendering requires upgrading to `testthat` 3rd edition. It was discussed by the team that we shouldn't upgrade this repo without upgrading the others.


Fixes #71


Example usage.

```
library(shiny)
library(teal.reporter)
library(ggplot2)

ui <- fluidPage(
  # please, specify specific bootstrap version and theme
  theme = bslib::bs_theme(version = "4"),
  titlePanel(""),
  tabsetPanel(
    tabPanel(
      "main App",
      tags$br(),
      sidebarLayout(
        sidebarPanel(
          uiOutput("encoding")
        ),
        mainPanel(
          tabsetPanel(
            id = "tabs",
            tabPanel("Plot", plotOutput("dist_plot"))
          )
        )
      )
    ),
    ### REPORTER
    tabPanel(
      "Previewer",
      reporter_previewer_ui("prev")
    )
    ###
  )
)
server <- function(input, output, session) {
  output$encoding <- renderUI({
    tagList(
      ### REPORTER
      teal.reporter::simple_reporter_ui("simple_reporter"),
      ###
      if (input$tabs == "Plot") {
        sliderInput(
          "binwidth",
          "binwidth",
          min = 2,
          max = 10,
          value = 8
        )
      } else {
        NULL
      }
    )
  })
  plot <- reactive({
    req(input$binwidth)
    x <- mtcars$mpg
    ggplot2::ggplot(data = mtcars, ggplot2::aes(x = mpg)) +
      ggplot2::geom_histogram(binwidth = input$binwidth)
  })
  output$dist_plot <- renderPlot(plot())
  
  ### REPORTER
  reporter <- teal.reporter::Reporter$new()
  card_fun <- function(card = ReportCard$new(), comment) {
    if (input$tabs == "Plot") {
      card$set_name("Plot Module")
      card$append_text("My plot", "header2")
      card$append_plot(plot())
      card$append_text(
        paste(
          c(
            "x <- mtcars$mpg",
            "ggplot2::ggplot(data = mtcars, ggplot2::aes(x = mpg)) +",
            paste0("ggplot2::geom_histogram(binwidth = ", input$binwidth, ")")
          ),
          collapse = "\n"
        ),
        "verbatim"
      )
    }
    if (!comment == "") {
      card$append_text("Comment", "header3")
      card$append_text(comment)
    }
    card
  }
  teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)
  teal.reporter::reporter_previewer_srv("prev", reporter)
  ###
}

shinyApp(ui = ui, server = server)

```


