### PR TITLE
support the toc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Updated the `AddCardModule` comment input to have an active cursor when adding a card.
 * Updated report previewer to support preview of multiline comment.
-* Added support for a table of content for reporter documents.
+* Added support for a table of contents for reporter documents.
 
 ### New features
 * Added the new `RcodeBlock` block for a custom `rmarkdown` r chunk.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Updated the `AddCardModule` comment input to have an active cursor when adding a card.
 * Updated report previewer to support preview of multiline comment.
+* Added support for a table of content for reporter documents.
 
 ### New features
 * Added the new `RcodeBlock` block for a custom `rmarkdown` r chunk.

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -245,7 +245,7 @@ reporter_download_inputs <- function(rmd_yaml_args, rmd_output, session) {
             selected = rmd_yaml_args$output
           )
         ),
-        toc = shiny::checkboxInput(session$ns("toc"), label = "table of content", value = rmd_yaml_args$toc)
+        toc = shiny::checkboxInput(session$ns("toc"), label = "Include Table of Contents", value = rmd_yaml_args$toc)
       )
     })
   )

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -38,7 +38,7 @@ download_report_button_ui <- function(id) {
 #' `pdflatex` has to be installed to use the `"pdf_document"` output. If vector is named then the names
 #' will appear in the `UI`.
 #' @param rmd_yaml_args `named list` vector with `Rmd` `yaml` header fields and their default values.
-#' Default `list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document")`.
+#' Default `list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document", toc = FALSE)`.
 #' Please update only values at this moment.
 #' @return `shiny::moduleServer`
 #' @export
@@ -50,7 +50,8 @@ download_report_button_srv <- function(id,
                                        ),
                                        rmd_yaml_args = list(
                                          author = "NEST", title = "Report",
-                                         date = as.character(Sys.Date()), output = "html_document"
+                                         date = as.character(Sys.Date()), output = "html_document",
+                                         toc = FALSE
                                        )) {
   checkmate::assert_class(reporter, "Reporter")
   checkmate::assert_subset(rmd_output, c(
@@ -58,7 +59,7 @@ download_report_button_srv <- function(id,
     "powerpoint_presentation", "word_document"
   ))
   checkmate::assert_list(rmd_yaml_args, names = "named")
-  checkmate::assert_true(all(c("author", "title", "date", "output") %in% names(rmd_yaml_args)))
+  checkmate::assert_true(all(c("author", "title", "date", "output", "toc") %in% names(rmd_yaml_args)))
 
   shiny::moduleServer(
     id,
@@ -243,7 +244,8 @@ reporter_download_inputs <- function(rmd_yaml_args, rmd_output, session) {
             choices = rmd_output,
             selected = rmd_yaml_args$output
           )
-        )
+        ),
+        toc = shiny::checkboxInput(session$ns("toc"), label = "table of content", value = rmd_yaml_args$toc)
       )
     })
   )

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -35,7 +35,7 @@ reporter_previewer_ui <- function(id) {
 #' by default all possible `c("pdf_document", "html_document", "powerpoint_presentation", "word_document")`.
 #' If vector is named then those names will appear in the `UI`.
 #' @param rmd_yaml_args `named list` vector with `Rmd` `yaml` header fields and their default values.
-#' Default `list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document")`.
+#' Default `list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document", toc = FALSE)`.
 #' Please update only values at this moment.
 #' @export
 reporter_previewer_srv <- function(id, reporter, rmd_output = c(
@@ -44,7 +44,8 @@ reporter_previewer_srv <- function(id, reporter, rmd_output = c(
                                      "word" = "word_document"
                                    ), rmd_yaml_args = list(
                                      author = "NEST", title = "Report",
-                                     date = as.character(Sys.Date()), output = "html_document"
+                                     date = as.character(Sys.Date()), output = "html_document",
+                                     toc = FALSE
                                    )) {
   checkmate::assert_class(reporter, "Reporter")
   checkmate::assert_list(rmd_yaml_args)

--- a/man/download_report_button_srv.Rd
+++ b/man/download_report_button_srv.Rd
@@ -10,7 +10,7 @@ download_report_button_srv(
   rmd_output = c(html = "html_document", pdf = "pdf_document", powerpoint =
     "powerpoint_presentation", word = "word_document"),
   rmd_yaml_args = list(author = "NEST", title = "Report", date =
-    as.character(Sys.Date()), output = "html_document")
+    as.character(Sys.Date()), output = "html_document", toc = FALSE)
 )
 }
 \arguments{
@@ -24,7 +24,7 @@ by default all possible \code{c("pdf_document", "html_document", "powerpoint_pre
 will appear in the \code{UI}.}
 
 \item{rmd_yaml_args}{\verb{named list} vector with \code{Rmd} \code{yaml} header fields and their default values.
-Default \code{list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document")}.
+Default \code{list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document", toc = FALSE)}.
 Please update only values at this moment.}
 }
 \value{

--- a/man/reporter_previewer_srv.Rd
+++ b/man/reporter_previewer_srv.Rd
@@ -10,7 +10,7 @@ reporter_previewer_srv(
   rmd_output = c(html = "html_document", pdf = "pdf_document", powerpoint =
     "powerpoint_presentation", word = "word_document"),
   rmd_yaml_args = list(author = "NEST", title = "Report", date =
-    as.character(Sys.Date()), output = "html_document")
+    as.character(Sys.Date()), output = "html_document", toc = FALSE)
 )
 }
 \arguments{
@@ -23,7 +23,7 @@ by default all possible \code{c("pdf_document", "html_document", "powerpoint_pre
 If vector is named then those names will appear in the \code{UI}.}
 
 \item{rmd_yaml_args}{\verb{named list} vector with \code{Rmd} \code{yaml} header fields and their default values.
-Default \code{list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document")}.
+Default \code{list(author = "NEST", title = "Report", date = Sys.Date(), output = "html_document", toc = FALSE)}.
 Please update only values at this moment.}
 }
 \description{

--- a/tests/testthat/test-DownloadReportModule.R
+++ b/tests/testthat/test-DownloadReportModule.R
@@ -18,6 +18,7 @@ testthat::test_that("download_report_button_srv - render and downlaod a document
       session$setInputs(`output` = "html_document")
       session$setInputs(`title` = "TITLE")
       session$setInputs(`author` = "AUTHOR")
+      session$setInputs(`toc` = TRUE)
       session$setInputs(`download_data` = 0)
 
       f <- output$download_data
@@ -76,7 +77,7 @@ testthat::test_that("report_render_and_compress - invalid arguments", {
 })
 
 testthat::test_that("report_render_and_compress - render an html document", {
-  input <- list(author = "NEST", title = "Report", output = "html_document")
+  input <- list(author = "NEST", title = "Report", output = "html_document", toc = FALSE)
   temp_dir <- tempdir()
   knitr_args <- list()
   res_path <- report_render_and_compress(reporter, input, knitr_args, temp_dir)

--- a/tests/testthat/test-PreviewerReportModule.R
+++ b/tests/testthat/test-PreviewerReportModule.R
@@ -17,6 +17,7 @@ testthat::test_that("reporter_previewer_srv - render and downlaod a document", {
       session$setInputs(`output` = "html_document")
       session$setInputs(`title` = "TITLE")
       session$setInputs(`author` = "AUTHOR")
+      session$setInputs(`toc` = FALSE)
       session$setInputs(`download_data_prev` = 0)
 
       f <- output$download_data_prev


### PR DESCRIPTION
closes #130 

I propose a  comprehensive solution for toc where it could be TRUE or FALSE. The additional arguments like toc_float are not supported as require another layer of complexity. 

This work so well as the `as_yaml_auto` is automatically resolve the flat structure to nested  for us.