### PR TITLE
init the new modal for removal of a card in the previewer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Updated report previewer to support preview of multiline comment.
 * Added support for a table of contents for reporter documents.
 * Added support for global `knitr` options in the render method in the Render class.
+* Improved look of the remove card modal in the previewer module.
 
 ### Miscellaneous
 * Updated `append_src` method of `TealReportCard` to not add additional "R Code" Subtitle.

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -124,9 +124,14 @@ reporter_previewer_srv <- function(id,
       shiny::observeEvent(input$card_remove_id, {
         shiny::showModal(
           shiny::modalDialog(
-            title = sprintf(
-              "Do you really want to remove the card %s from the Report?",
-              input$card_remove_id
+            title = "Remove the Report Card",
+            shiny::tags$p(
+              shiny::HTML(
+                sprintf(
+                  "Do you really want to remove <strong>the card %s</strong> from the Report?",
+                  input$card_remove_id
+                )
+              )
             ),
             footer = shiny::tagList(
               shiny::modalButton("Cancel"),

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -134,7 +134,14 @@ reporter_previewer_srv <- function(id,
               )
             ),
             footer = shiny::tagList(
-              shiny::modalButton("Cancel"),
+              shiny::tags$button(
+                type = "button",
+                class = "btn btn-danger",
+                `data-dismiss` = "modal",
+                `data-bs-dismiss` = "modal",
+                NULL,
+                "Cancel"
+              ),
               shiny::actionButton(ns("remove_card_ok"), "OK", class = "btn-warning")
             )
           )

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -124,15 +124,16 @@ reporter_previewer_srv <- function(id,
       shiny::observeEvent(input$card_remove_id, {
         shiny::showModal(
           shiny::modalDialog(
-          title = sprintf(
-            "Do you really want to remove the card %s from the Report?",
-            input$card_remove_id
-          ),
-          footer = shiny::tagList(
-            shiny::modalButton("Cancel"),
-            shiny::actionButton(ns("remove_card_ok"), "OK", class = "btn-warning")
+            title = sprintf(
+              "Do you really want to remove the card %s from the Report?",
+              input$card_remove_id
+            ),
+            footer = shiny::tagList(
+              shiny::modalButton("Cancel"),
+              shiny::actionButton(ns("remove_card_ok"), "OK", class = "btn-warning")
+            )
           )
-          ))
+        )
       })
 
       shiny::observeEvent(input$remove_card_ok, {

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -122,7 +122,22 @@ reporter_previewer_srv <- function(id,
       })
 
       shiny::observeEvent(input$card_remove_id, {
+        shiny::showModal(
+          shiny::modalDialog(
+          title = sprintf(
+            "Do you really want to remove the card %s from the Report?",
+            input$card_remove_id
+          ),
+          footer = shiny::tagList(
+            shiny::modalButton("Cancel"),
+            shiny::actionButton(ns("remove_card_ok"), "OK", class = "btn-warning")
+          )
+          ))
+      })
+
+      shiny::observeEvent(input$remove_card_ok, {
         reporter$remove_cards(input$card_remove_id)
+        shiny::removeModal()
       })
 
       shiny::observeEvent(input$card_up_id, {
@@ -209,12 +224,7 @@ add_previewer_js <- function(ns) {
           $(document).ready(function(event) {
             $("body").on("click", "span.card_remove_id", function() {
               let val = $(this).data("cardid");
-              let msg_confirm = "Do you really want to remove the card " + val + " from the Report?";
-              let answer = confirm(msg_confirm);
-              if (answer) {
-                Shiny.setInputValue("%s", val, {priority: "event"});
-                $("#panel_card_" + val).remove();
-              }
+              Shiny.setInputValue("%s", val, {priority: "event"});
             });
 
             $("body").on("click", "span.card_up_id", function() {

--- a/tests/testthat/test-PreviewerReportModule.R
+++ b/tests/testthat/test-PreviewerReportModule.R
@@ -88,6 +88,7 @@ testthat::test_that("reporter_previewer_srv - remove a card", {
     expr = {
       len_prior <- length(reporter$get_cards())
       session$setInputs(`card_remove_id` = 1L)
+      session$setInputs(`remove_card_ok` = TRUE)
       len_post <- length(reporter$get_cards())
 
       testthat::expect_identical(len_prior, len_post + 1L)


### PR DESCRIPTION
closes #138 

The remove card in the reporter from previewer functionality is partly transferred to the server side.
With this PR the modals should be consistent as are using the same shiny internals.
The thing we should validate is proposed event path =  jquery observer -> open modal observer -> remove card and modal observer.