### PR TITLE
Change color of buttons in modals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 ### Enhancements
 
+* Changed modal button colors to align with their purpose and with other modals.
 * Updated the `AddCardModule` comment input to have an active cursor when adding a card.
 * Updated report previewer to support preview of multiline comment.
 * Added support for a table of contents for reporter documents.

--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -123,7 +123,7 @@ add_card_button_srv <- function(id, reporter, card_fun) {
           footer = shiny::div(
             shiny::tags$button(
               type = "button",
-              class = "btn btn-danger",
+              class = "btn btn-secondary",
               `data-dismiss` = "modal",
               `data-bs-dismiss` = "modal",
               NULL,

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -111,7 +111,7 @@ download_report_button_srv <- function(id,
           footer = shiny::tagList(
             shiny::tags$button(
               type = "button",
-              class = "btn btn-danger",
+              class = "btn btn-secondary",
               `data-dismiss` = "modal",
               `data-bs-dismiss` = "modal",
               NULL,

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -136,13 +136,13 @@ reporter_previewer_srv <- function(id,
             footer = shiny::tagList(
               shiny::tags$button(
                 type = "button",
-                class = "btn btn-danger",
+                class = "btn btn-secondary",
                 `data-dismiss` = "modal",
                 `data-bs-dismiss` = "modal",
                 NULL,
                 "Cancel"
               ),
-              shiny::actionButton(ns("remove_card_ok"), "OK", class = "btn-warning")
+              shiny::actionButton(ns("remove_card_ok"), "OK", class = "btn-danger")
             )
           )
         )

--- a/R/ResetModule.R
+++ b/R/ResetModule.R
@@ -63,13 +63,13 @@ reset_report_button_srv <- function(id, reporter) {
             footer = shiny::tagList(
               shiny::tags$button(
                 type = "button",
-                class = "btn btn-danger",
+                class = "btn btn-secondary",
                 `data-dismiss` = "modal",
                 `data-bs-dismiss` = "modal",
                 NULL,
                 "Cancel"
               ),
-              shiny::actionButton(ns("reset_reporter_ok"), "Reset", class = "btn-warning")
+              shiny::actionButton(ns("reset_reporter_ok"), "Reset", class = "btn-danger")
             )
           )
         )


### PR DESCRIPTION
Changes the colors of buttons in the various modals.

- "Cancel" buttons are color "secondary".
- "Remove" buttons are color "danger"
- "Add" buttons are color "primary"

Fixes #179 
