### PR TITLE
Suppresses the warning message because of partial arg match

### DIFF
--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -65,7 +65,7 @@ download_report_button_srv <- function(id,
   checkmate::assert_list(rmd_yaml_args, names = "named")
   checkmate::assert_names(
     names(rmd_yaml_args),
-    subset = c("author", "title", "date", "output", "toc"),
+    subset.of = c("author", "title", "date", "output", "toc"),
     must.include = "output"
   )
   checkmate::assert_true(rmd_yaml_args[["output"]] %in% rmd_output)

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -62,7 +62,7 @@ reporter_previewer_srv <- function(id,
   checkmate::assert_list(rmd_yaml_args, names = "named")
   checkmate::assert_names(
     names(rmd_yaml_args),
-    subset = c("author", "title", "date", "output", "toc"),
+    subset.of = c("author", "title", "date", "output", "toc"),
     must.include = "output"
   )
   checkmate::assert_true(rmd_yaml_args[["output"]] %in% rmd_output)


### PR DESCRIPTION
Suppresses the warning message because of partial arg match in the `checkmate::assert_names`

Example app to test:
```r
options(warnPartialMatchArgs = TRUE)
data <- teal_data()
data <- within(data, {
  library(nestcolor)
  ADSL <- teal.modules.general::rADSL
})
datanames <- c("ADSL")
datanames(data) <- datanames
join_keys(data) <- default_cdisc_join_keys[datanames]
app <- teal::init(
  data = data,
  modules = teal::modules(
    teal.modules.general::tm_a_pca(
      "PCA",
      dat = teal.transform::data_extract_spec(
        dataname = "ADSL",
        select = teal.transform::select_spec(
          choices = teal.transform::variable_choices(
            data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")
          ),
          selected = c("BMRKR1", "AGE"),
          multiple = TRUE
        ),
        filter = NULL
      ),
      ggplot2_args = teal.widgets::ggplot2_args(
        labs = list(subtitle = "Plot generated by PCA Module")
      )
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}

# Warning in checkmate::assert_names(names(rmd_yaml_args), subset = c("author",  :
#   partial argument match of 'subset' to 'subset.of'
```