### PR TITLE
update repo roster link

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.reporter 0.2.1.9011
+# teal.reporter 0.2.1.9012
 
 * `add_card_button_srv` allows to specify `card_fun` with `label` parameter for card's title & content customization.
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ If you encounter a bug or you have a feature request - please file an issue. For
 
 ### Stargazers
 
-[![Stargazers repo roster for @insightsengineering/teal.reporter](https://reporoster.com/stars/insightsengineering/teal.reporter)](https://github.com/insightsengineering/teal.reporter/stargazers)
+[![Stargazers repo roster for @insightsengineering/teal.reporter](http://reporoster.com/stars/insightsengineering/teal.reporter)](https://github.com/insightsengineering/teal.reporter/stargazers)
 
 ### Forkers
 
-[![Forkers repo roster for @insightsengineering/teal.reporter](https://reporoster.com/forks/insightsengineering/teal.reporter)](https://github.com/insightsengineering/teal.reporter/network/members)
+[![Forkers repo roster for @insightsengineering/teal.reporter](http://reporoster.com/forks/insightsengineering/teal.reporter)](https://github.com/insightsengineering/teal.reporter/network/members)


### PR DESCRIPTION
Related with https://github.com/insightsengineering/teal/issues/949, updating the link to `reporoster` in README.