### PR TITLE
187 color scheme for disabled button

### DIFF
--- a/inst/css/Previewer.css
+++ b/inst/css/Previewer.css
@@ -14,10 +14,10 @@ a.disabled {
   text-decoration: none;
 }
 
-[id$=download_data_prev].disabled {
-  background-color: darkgrey;
-}
-[id$=download_data].disabled {
+a[id$=download_data].disabled,
+a[id$=download_data_prev].disabled {
+  border: 0;
+  color: white;
   background-color: darkgrey;
 }
 

--- a/inst/css/Previewer.css
+++ b/inst/css/Previewer.css
@@ -14,6 +14,13 @@ a.disabled {
   text-decoration: none;
 }
 
+[id$=download_data_prev].disabled {
+  background-color: darkgrey;
+}
+[id$=download_data].disabled {
+  background-color: darkgrey;
+}
+
 /* icons in the previewer */
 .icon_previewer {
   float:right;


### PR DESCRIPTION
Closes #187 

Updated background color of two buttons (anchor elements) identified by _partial ids_ in disabled state.

The background color is `darkgrey` nad text color is `white`.

![image](https://github.com/insightsengineering/teal.reporter/assets/114988527/1c619023-b017-4fad-897c-ffb604e74ef4)
![image](https://github.com/insightsengineering/teal.reporter/assets/114988527/a0a49e05-5efc-4ad6-b5aa-9725c949411e)
