### PR TITLE
204 Add "rendering in progress" info

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
           - R6
           - rmarkdown
           - shiny
+          - shinybusy
           - shinyWidgets
           - yaml
           - zip

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     R6,
     rmarkdown (>= 2.19),
     shiny (>= 1.6.0),
+    shinybusy,
     shinyWidgets (>= 0.5.1),
     yaml (>= 1.1.0),
     zip (>= 1.1.0)
@@ -50,10 +51,11 @@ RdMacros:
     lifecycle
 Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,
     rstudio/htmltools, yihui/knitr, r-lib/lifecycle, r-lib/R6,
-    rstudio/rmarkdown, rstudio/shiny, dreamRs/shinyWidgets,
-    yaml=vubiostat/r-yaml, r-lib/zip, davidgohel/flextable, rstudio/DT,
-    yihui/formatR, tidyverse/ggplot2, deepayan/lattice, cran/png,
-    insightsengineering/rtables, r-lib/testthat, rstudio/tinytex
+    rstudio/rmarkdown, rstudio/shiny, dreamRs/shinybusy,
+    dreamRs/shinyWidgets, yaml=vubiostat/r-yaml, r-lib/zip,
+    davidgohel/flextable, rstudio/DT, yihui/formatR, tidyverse/ggplot2,
+    deepayan/lattice, cran/png, insightsengineering/rtables,
+    r-lib/testthat, rstudio/tinytex
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.reporter 0.3.0.9003
 
+### Enhancements
+
+* Added blocking of "Download" buttons while report is rendering, using the `shinybusy` package.
+
 # teal.reporter 0.3.0
 
 ### Enhancements

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -142,7 +142,6 @@ download_report_button_srv <- function(id,
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
           shinybusy::block(id = ns("download_data"), text = "", type = "dots")
-          Sys.sleep(3)
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -141,7 +141,7 @@ download_report_button_srv <- function(id,
         },
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
-          shinybusy::block(id = ns("download_data"), text = NULL, type = "dots", messageFontSize = "0px")
+          shinybusy::block(id = ns("download_data"), text = NULL, type = "dots")
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -142,6 +142,7 @@ download_report_button_srv <- function(id,
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
           shinybusy::block(id = ns("download_data"), text = NULL, type = "dots")
+          Sys.sleep(3)
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -141,10 +141,12 @@ download_report_button_srv <- function(id,
         },
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
+          shinybusy::block(id = ns("download_data"), text = NULL, type = "dots", messageFontSize = "0px")
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode
           report_render_and_compress(reporter, input_list, global_knitr, file)
+          shinybusy::unblock(id = ns("download_data"))
         },
         contentType = "application/zip"
       )

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -141,7 +141,7 @@ download_report_button_srv <- function(id,
         },
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
-          shinybusy::block(id = ns("download_data"), text = NULL, type = "dots")
+          shinybusy::block(id = ns("download_data"), text = "", type = "dots")
           Sys.sleep(3)
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -193,7 +193,7 @@ reporter_previewer_srv <- function(id,
         },
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
-          shinybusy::block(id = ns("download_data_prev"), text = NULL, type = "dots", messageFontSize = "0px")
+          shinybusy::block(id = ns("download_data_prev"), text = NULL, type = "dots")
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -194,6 +194,7 @@ reporter_previewer_srv <- function(id,
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
           shinybusy::block(id = ns("download_data_prev"), text = NULL, type = "dots")
+          Sys.sleep(3)
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -193,10 +193,12 @@ reporter_previewer_srv <- function(id,
         },
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
+          shinybusy::block(id = ns("download_data_prev"), text = NULL, type = "dots", messageFontSize = "0px")
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode
           report_render_and_compress(reporter, input_list, global_knitr, file)
+          shinybusy::unblock(id = ns("download_data_prev"))
         },
         contentType = "application/zip"
       )

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -193,7 +193,7 @@ reporter_previewer_srv <- function(id,
         },
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
-          shinybusy::block(id = ns("download_data_prev"), text = NULL, type = "dots")
+          shinybusy::block(id = ns("download_data_prev"), text = "", type = "dots")
           Sys.sleep(3)
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -194,7 +194,6 @@ reporter_previewer_srv <- function(id,
         content = function(file) {
           shiny::showNotification("Rendering and Downloading the document.")
           shinybusy::block(id = ns("download_data_prev"), text = "", type = "dots")
-          Sys.sleep(3)
           input_list <- lapply(names(rmd_yaml_args), function(x) input[[x]])
           names(input_list) <- names(rmd_yaml_args)
           if (is.logical(input$showrcode)) global_knitr[["echo"]] <- input$showrcode

--- a/inst/css/Previewer.css
+++ b/inst/css/Previewer.css
@@ -22,3 +22,8 @@ a.disabled {
   margin-top:10px;
   color:#337ab7;
 }
+
+/* prevents oversizing elements covered by shinybusy::block */
+.nx-block-temporary-position {
+  min-height: 0 !important;
+}


### PR DESCRIPTION
Closes #204.

Added blocking of download buttons with `shinybusy::block`.

#### TESTING APP
```
devtools::load_all()
library(teal.modules.general)

data <- teal_data()
data <- within(data, {
  library(nestcolor)
  ADSL <- teal.modules.general::rADSL
})
datanames <- c("ADSL")
datanames(data) <- datanames
join_keys(data) <- default_cdisc_join_keys[datanames]

app <- teal::init(
  data = data,
  modules = teal::modules(
    teal.modules.general::tm_a_regression(
      label = "Regression",
      response = teal.transform::data_extract_spec(
        dataname = "ADSL",
        select = teal.transform::select_spec(
          label = "Select variable:",
          choices = "BMRKR1",
          selected = "BMRKR1",
          multiple = FALSE,
          fixed = TRUE
        )
      ),
      regressor = teal.transform::data_extract_spec(
        dataname = "ADSL",
        select = teal.transform::select_spec(
          label = "Select variables:",
          choices = teal.transform::variable_choices(data[["ADSL"]], c("AGE", "SEX", "RACE")),
          selected = "AGE",
          multiple = TRUE,
          fixed = FALSE
        )
      ),
      ggplot2_args = teal.widgets::ggplot2_args(
        labs = list(subtitle = "Plot generated by Regression Module")
      )
    )
  )
)
runApp(app, launch.browser = TRUE)
```