### PR TITLE
vbump shinybusy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     R6,
     rmarkdown (>= 2.19),
     shiny (>= 1.6.0),
-    shinybusy,
+    shinybusy (>= 0.3.2),
     shinyWidgets (>= 0.5.1),
     yaml (>= 1.1.0),
     zip (>= 1.1.0)


### PR DESCRIPTION
`block()` and `unblock()` functions are available since version [`0.3.2` ](https://github.com/dreamRs/shinybusy/blob/4e7b48dede431fec3355e89e5396f2ad31214f3a/NEWS.md?plain=1#L3)

This is correctly identified by verdepcheck pipelines - [latest run](https://github.com/insightsengineering/teal.reporter/actions/runs/8585971368). This is failing with the below:
```
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Error ('test-DownloadReportModule.R:13:3'): download_report_button_srv - render and downlaod a document ──
  Error: 'block' is not an exported object from 'namespace:shinybusy'
```

I will be running verdepcheck pipelines manually. You can track its status here: https://github.com/insightsengineering/teal.reporter/actions/workflows/scheduled.yaml?query=branch%3Afix_verdepcheck