### PR TITLE
Adds missing repo from `verdepcheck` section in `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,8 +57,9 @@ Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,
     r-lib/R6, insightsengineering/rlistings, rstudio/rmarkdown,
     insightsengineering/rtables, rstudio/shiny, dreamRs/shinybusy,
     dreamRs/shinyWidgets, vubiostat/r-yaml, r-lib/zip, rstudio/DT,
-    yihui/formatR, tidyverse/ggplot2, deepayan/lattice, cran/png,
-    r-lib/testthat, rstudio/tinytex, r-lib/withr
+    yihui/formatR, insightsengineering/formatters, tidyverse/ggplot2, 
+    deepayan/lattice, cran/png, r-lib/testthat, rstudio/tinytex,
+    r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     flextable (>= 0.9.2),
     grid,
     htmltools (>= 0.5.4),
-    knitr (>= 1.34),
+    knitr (>= 1.42),
     lifecycle (>= 0.2.0),
     R6,
     rlistings (>= 0.2.8),
@@ -54,11 +54,11 @@ RdMacros:
     lifecycle
 Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,
     davidgohel/flextable, rstudio/htmltools, yihui/knitr, r-lib/lifecycle,
-    cran/png, r-lib/R6, insightsengineering/rlistings, rstudio/rmarkdown,
+    r-lib/R6, insightsengineering/rlistings, rstudio/rmarkdown,
     insightsengineering/rtables, rstudio/shiny, dreamRs/shinybusy,
     dreamRs/shinyWidgets, vubiostat/r-yaml, r-lib/zip, rstudio/DT,
-    yihui/formatR, tidyverse/ggplot2, deepayan/lattice, r-lib/testthat,
-    rstudio/tinytex, r-lib/withr
+    yihui/formatR, tidyverse/ggplot2, deepayan/lattice, cran/png,
+    r-lib/testthat, rstudio/tinytex, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

### Changes description

- `knitr` minimum version updated to standard 1.42
  - Not essential as we're no longer building the package
- Missing `formatters` repo was causing problems in `max` strategy
- Reorder packages to follow `Depends` / `Imports` / `Suggests`
