### PR TITLE
Fix failed pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,8 @@ repos:
           - shinyWidgets
           - yaml
           - zip
+          - rlistings
+          - rtables
       - id: spell-check
         name: Check spelling with `spelling`
         exclude: >

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,8 @@ Suggests:
     tinytex,
     withr (>= 2.0.0)
 VignetteBuilder:
-    knitr
+    knitr,
+    rmarkdown
 RdMacros:
     lifecycle
 Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,

--- a/R/PictureBlock.R
+++ b/R/PictureBlock.R
@@ -28,7 +28,7 @@ PictureBlock <- R6::R6Class( # nolint: object_name_linter.
     #' @param content (`ggplot` or `grob` or `trellis`) a picture in this `PictureBlock`
     #'
     #' @return `self`, invisibly.
-    #' @examples
+    #' @examplesIf require("ggplot2") && require("lattice")
     #' library(ggplot2)
     #' library(lattice)
     #'

--- a/R/Renderer.R
+++ b/R/Renderer.R
@@ -38,7 +38,7 @@ Renderer <- R6::R6Class( # nolint: object_name_linter.
     #' @details `r global_knitr_details()`
     #'
     #' @return Character vector constituting `rmarkdown` text (`yaml` header + body), ready to be rendered.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(yaml)
     #' library(rtables)
     #' library(ggplot2)
@@ -141,7 +141,7 @@ Renderer <- R6::R6Class( # nolint: object_name_linter.
     #' @details `r global_knitr_details()`
     #'
     #' @return `character` path to the output.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(yaml)
     #' library(ggplot2)
     #'

--- a/R/ReportCard.R
+++ b/R/ReportCard.R
@@ -42,7 +42,7 @@ ReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @param plot (`ggplot` or `grob` or `trellis`) plot object.
     #' @param dim (`numeric(2)`) width and height in pixels.
     #' @return `self`, invisibly.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #'
     #' card <- ReportCard$new()$append_plot(
@@ -132,7 +132,7 @@ ReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @param key (`character(1)`) string specifying the metadata key.
     #' @param value value associated with the metadata key.
     #' @return `self`, invisibly.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #'
     #' card <- ReportCard$new()$append_text("Some text")$append_plot(
@@ -172,7 +172,7 @@ ReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @description Convert the `ReportCard` to a list, including content and metadata.
     #' @param output_dir (`character`) with a path to the directory where files will be copied.
     #' @return (`named list`) a `ReportCard` representation.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #'
     #' card <- ReportCard$new()$append_text("Some text")$append_plot(
@@ -207,7 +207,7 @@ ReportCard <- R6::R6Class( # nolint: object_name_linter.
     #' @param card (`named list`) a `ReportCard` representation.
     #' @param output_dir (`character`) with a path to the directory where a file will be copied.
     #' @return `self`, invisibly.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #'
     #' card <- ReportCard$new()$append_text("Some text")$append_plot(

--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -25,7 +25,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #'
     #' @param cards (`ReportCard`) or a list of such objects
     #' @return `self`, invisibly.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #' library(rtables)
     #'
@@ -57,7 +57,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #' @description Retrieves all `ReportCard` objects contained in the `Reporter`.
     #'
     #' @return A (`list`) of [`ReportCard`] objects.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #' library(rtables)
     #'
@@ -89,7 +89,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #' @param sep An optional separator to insert between each content block.
     #' Default is a `NewpageBlock$new()`object.
     #' @return `list()` list of `TableBlock`, `TextBlock`, `PictureBlock` and `NewpageBlock`.
-    #' @examples
+    #' @examplesIf require("ggplot2")
     #' library(ggplot2)
     #' library(rtables)
     #'

--- a/man/PictureBlock.Rd
+++ b/man/PictureBlock.Rd
@@ -10,11 +10,7 @@ It's designed to handle plots from packages such as \code{ggplot2}, \code{grid},
 It can save plots to files, set titles and specify dimensions.
 }
 \examples{
-
-## ------------------------------------------------
-## Method `PictureBlock$set_content`
-## ------------------------------------------------
-
+\dontshow{if (require("ggplot2") && require("lattice")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(ggplot2)
 library(lattice)
 
@@ -29,6 +25,7 @@ block$set_content(bwplot(1))
 PictureBlock <- getFromNamespace("PictureBlock", "teal.reporter")
 block <- PictureBlock$new()
 block$set_content(ggplotGrob(ggplot(iris)))
+\dontshow{\}) # examplesIf}
 
 ## ------------------------------------------------
 ## Method `PictureBlock$set_title`
@@ -134,27 +131,6 @@ Raises error if argument is not a \code{ggplot}, \code{grob} or \code{trellis} p
 \subsection{Returns}{
 \code{self}, invisibly.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-library(lattice)
-
-PictureBlock <- getFromNamespace("PictureBlock", "teal.reporter")
-block <- PictureBlock$new()
-block$set_content(ggplot(iris))
-
-PictureBlock <- getFromNamespace("PictureBlock", "teal.reporter")
-block <- PictureBlock$new()
-block$set_content(bwplot(1))
-
-PictureBlock <- getFromNamespace("PictureBlock", "teal.reporter")
-block <- PictureBlock$new()
-block$set_content(ggplotGrob(ggplot(iris)))
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-PictureBlock-set_title"></a>}}

--- a/man/Renderer.Rd
+++ b/man/Renderer.Rd
@@ -9,19 +9,7 @@ A class for rendering reports from \code{ContentBlock} into various formats usin
 It supports \code{TextBlock}, \code{PictureBlock}, \code{RcodeBlock}, \code{NewpageBlock}, and \code{TableBlock}.
 }
 \examples{
-
-## ------------------------------------------------
-## Method `Renderer$new`
-## ------------------------------------------------
-
-Renderer <- getFromNamespace("Renderer", "teal.reporter")
-Renderer$new()
-
-
-## ------------------------------------------------
-## Method `Renderer$renderRmd`
-## ------------------------------------------------
-
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(yaml)
 library(rtables)
 library(ggplot2)
@@ -62,12 +50,8 @@ md_header <- getFromNamespace("md_header", "teal.reporter")
 yaml_header <- md_header(as.yaml(yaml_l))
 Renderer <- getFromNamespace("Renderer", "teal.reporter")
 result_path <- Renderer$new()$renderRmd(reporter$get_blocks(), yaml_header)
-
-
-## ------------------------------------------------
-## Method `Renderer$render`
-## ------------------------------------------------
-
+\dontshow{\}) # examplesIf}
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(yaml)
 library(ggplot2)
 
@@ -105,6 +89,14 @@ md_header <- getFromNamespace("md_header", "teal.reporter")
 yaml_header <- md_header(as.yaml(yaml_l))
 Renderer <- getFromNamespace("Renderer", "teal.reporter")
 result_path <- Renderer$new()$render(Reporter$get_blocks(), yaml_header)
+\dontshow{\}) # examplesIf}
+
+## ------------------------------------------------
+## Method `Renderer$new`
+## ------------------------------------------------
+
+Renderer <- getFromNamespace("Renderer", "teal.reporter")
+Renderer$new()
 
 
 ## ------------------------------------------------
@@ -203,54 +195,6 @@ use \code{getOption('teal.reporter.global_knitr')}. These defaults include:
 \subsection{Returns}{
 Character vector constituting \code{rmarkdown} text (\code{yaml} header + body), ready to be rendered.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(yaml)
-library(rtables)
-library(ggplot2)
-
-ReportCard <- getFromNamespace("ReportCard", "teal.reporter")
-card1 <- ReportCard$new()
-
-card1$append_text("Header 2 text", "header2")
-card1$append_text("A paragraph of default text")
-card1$append_plot(
- ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
-
-ReportCard <- getFromNamespace("ReportCard", "teal.reporter")
-card2 <- ReportCard$new()
-
-card2$append_text("Header 2 text", "header2")
-card2$append_text("A paragraph of default text", "header2")
-lyt <- analyze(split_rows_by(basic_table(), "Day"), "Ozone", afun = mean)
-table_res2 <- build_table(lyt, airquality)
-card2$append_table(table_res2)
-card2$append_table(iris)
-card2$append_rcode("2+2", echo = FALSE)
-
-Reporter <- getFromNamespace("Reporter", "teal.reporter")
-reporter <- Reporter$new()
-reporter$append_cards(list(card1, card2))
-
-yaml_quoted <- getFromNamespace("yaml_quoted", "teal.reporter")
-yaml_l <- list(
-  author = yaml_quoted("NEST"),
-  title = yaml_quoted("Report"),
-  date = yaml_quoted("07/04/2019"),
-  output = list(html_document = list(toc = FALSE))
-)
-
-md_header <- getFromNamespace("md_header", "teal.reporter")
-yaml_header <- md_header(as.yaml(yaml_l))
-Renderer <- getFromNamespace("Renderer", "teal.reporter")
-result_path <- Renderer$new()$renderRmd(reporter$get_blocks(), yaml_header)
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Renderer-render"></a>}}
@@ -293,51 +237,6 @@ use \code{getOption('teal.reporter.global_knitr')}. These defaults include:
 \subsection{Returns}{
 \code{character} path to the output.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(yaml)
-library(ggplot2)
-
-ReportCard <- getFromNamespace("ReportCard", "teal.reporter")
-card1 <- ReportCard$new()
-
-card1$append_text("Header 2 text", "header2")
-card1$append_text("A paragraph of default text")
-card1$append_plot(
- ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
-
-ReportCard <- getFromNamespace("ReportCard", "teal.reporter")
-card2 <- ReportCard$new()
-
-card2$append_text("Header 2 text", "header2")
-card2$append_text("A paragraph of default text", "header2")
-lyt <- analyze(split_rows_by(basic_table(), "Day"), "Ozone", afun = mean)
-table_res2 <- build_table(lyt, airquality)
-card2$append_table(table_res2)
-card2$append_table(iris)
-card2$append_rcode("2+2", echo = FALSE)
-Reporter <- getFromNamespace("Reporter", "teal.reporter")$new()
-Reporter$append_cards(list(card1, card2))
-
-yaml_quoted <- getFromNamespace("yaml_quoted", "teal.reporter")
-yaml_l <- list(
-  author = yaml_quoted("NEST"),
-  title = yaml_quoted("Report"),
-  date = yaml_quoted("07/04/2019"),
-  output = list(html_document = list(toc = FALSE))
-)
-
-md_header <- getFromNamespace("md_header", "teal.reporter")
-yaml_header <- md_header(as.yaml(yaml_l))
-Renderer <- getFromNamespace("Renderer", "teal.reporter")
-result_path <- Renderer$new()$render(Reporter$get_blocks(), yaml_header)
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Renderer-get_output_dir"></a>}}

--- a/man/ReportCard.Rd
+++ b/man/ReportCard.Rd
@@ -14,6 +14,45 @@ For more information about the various blocks, refer to the vignette:
 \code{vignette("teal-reporter-blocks-overview", "teal.reporter")}.
 }
 \examples{
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
+
+card <- ReportCard$new()$append_plot(
+  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
+)
+\dontshow{\}) # examplesIf}
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
+
+card <- ReportCard$new()$append_text("Some text")$append_plot(
+  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
+)$append_text("Some text")$append_metadata(key = "lm",
+                  value = lm(Ozone ~ Solar.R, airquality))
+card$get_content()
+card$get_metadata()
+\dontshow{\}) # examplesIf}
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
+
+card <- ReportCard$new()$append_text("Some text")$append_plot(
+  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
+)$append_text("Some text")$append_metadata(key = "lm",
+                  value = lm(Ozone ~ Solar.R, airquality))
+card$get_content()
+
+card$to_list(tempdir())
+\dontshow{\}) # examplesIf}
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
+
+card <- ReportCard$new()$append_text("Some text")$append_plot(
+  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
+)$append_text("Some text")$append_metadata(key = "lm",
+                  value = lm(Ozone ~ Solar.R, airquality))
+card$get_content()
+
+ReportCard$new()$from_list(card$to_list(tempdir()), tempdir())
+\dontshow{\}) # examplesIf}
 
 ## ------------------------------------------------
 ## Method `ReportCard$new`
@@ -27,17 +66,6 @@ card <- ReportCard$new()
 ## ------------------------------------------------
 
 card <- ReportCard$new()$append_table(iris)
-
-
-## ------------------------------------------------
-## Method `ReportCard$append_plot`
-## ------------------------------------------------
-
-library(ggplot2)
-
-card <- ReportCard$new()$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
 
 
 ## ------------------------------------------------
@@ -82,20 +110,6 @@ card$get_metadata()
 
 
 ## ------------------------------------------------
-## Method `ReportCard$append_metadata`
-## ------------------------------------------------
-
-library(ggplot2)
-
-card <- ReportCard$new()$append_text("Some text")$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)$append_text("Some text")$append_metadata(key = "lm",
-                  value = lm(Ozone ~ Solar.R, airquality))
-card$get_content()
-card$get_metadata()
-
-
-## ------------------------------------------------
 ## Method `ReportCard$get_name`
 ## ------------------------------------------------
 
@@ -106,36 +120,6 @@ ReportCard$new()$set_name("NAME")$get_name()
 ## ------------------------------------------------
 
 ReportCard$new()$set_name("NAME")$get_name()
-
-## ------------------------------------------------
-## Method `ReportCard$to_list`
-## ------------------------------------------------
-
-library(ggplot2)
-
-card <- ReportCard$new()$append_text("Some text")$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)$append_text("Some text")$append_metadata(key = "lm",
-                  value = lm(Ozone ~ Solar.R, airquality))
-card$get_content()
-
-card$to_list(tempdir())
-
-
-## ------------------------------------------------
-## Method `ReportCard$from_list`
-## ------------------------------------------------
-
-library(ggplot2)
-
-card <- ReportCard$new()$append_text("Some text")$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)$append_text("Some text")$append_metadata(key = "lm",
-                  value = lm(Ozone ~ Solar.R, airquality))
-card$get_content()
-
-ReportCard$new()$from_list(card$to_list(tempdir()), tempdir())
-
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -230,19 +214,6 @@ Appends a plot to this \code{ReportCard}.
 \subsection{Returns}{
 \code{self}, invisibly.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-
-card <- ReportCard$new()$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ReportCard-append_text"></a>}}
@@ -419,22 +390,6 @@ Appends metadata to this \code{ReportCard}.
 \subsection{Returns}{
 \code{self}, invisibly.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-
-card <- ReportCard$new()$append_text("Some text")$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)$append_text("Some text")$append_metadata(key = "lm",
-                  value = lm(Ozone ~ Solar.R, airquality))
-card$get_content()
-card$get_metadata()
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ReportCard-get_name"></a>}}
@@ -504,23 +459,6 @@ Convert the \code{ReportCard} to a list, including content and metadata.
 \subsection{Returns}{
 (\verb{named list}) a \code{ReportCard} representation.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-
-card <- ReportCard$new()$append_text("Some text")$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)$append_text("Some text")$append_metadata(key = "lm",
-                  value = lm(Ozone ~ Solar.R, airquality))
-card$get_content()
-
-card$to_list(tempdir())
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ReportCard-from_list"></a>}}
@@ -543,23 +481,6 @@ Reconstructs the \code{ReportCard} from a list representation.
 \subsection{Returns}{
 \code{self}, invisibly.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-
-card <- ReportCard$new()$append_text("Some text")$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)$append_text("Some text")$append_metadata(key = "lm",
-                  value = lm(Ozone ~ Solar.R, airquality))
-card$get_content()
-
-ReportCard$new()$from_list(card$to_list(tempdir()), tempdir())
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ReportCard-clone"></a>}}

--- a/man/Reporter.Rd
+++ b/man/Reporter.Rd
@@ -18,18 +18,7 @@ if Report has an id when converting to JSON then It will be compared to the curr
 if Report has an id when converting to JSON then It will be compared to the currently available one.
 }
 \examples{
-
-## ------------------------------------------------
-## Method `Reporter$new`
-## ------------------------------------------------
-
-reporter <- Reporter$new()
-
-
-## ------------------------------------------------
-## Method `Reporter$append_cards`
-## ------------------------------------------------
-
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(ggplot2)
 library(rtables)
 
@@ -52,11 +41,8 @@ card2$append_table(iris)
 
 reporter <- Reporter$new()
 reporter$append_cards(list(card1, card2))
-
-## ------------------------------------------------
-## Method `Reporter$get_cards`
-## ------------------------------------------------
-
+\dontshow{\}) # examplesIf}
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(ggplot2)
 library(rtables)
 
@@ -80,11 +66,8 @@ card2$append_table(iris)
 reporter <- Reporter$new()
 reporter$append_cards(list(card1, card2))
 reporter$get_cards()
-
-## ------------------------------------------------
-## Method `Reporter$get_blocks`
-## ------------------------------------------------
-
+\dontshow{\}) # examplesIf}
+\dontshow{if (require("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(ggplot2)
 library(rtables)
 
@@ -108,6 +91,13 @@ card2$append_table(iris)
 reporter <- Reporter$new()
 reporter$append_cards(list(card1, card2))
 reporter$get_blocks()
+\dontshow{\}) # examplesIf}
+
+## ------------------------------------------------
+## Method `Reporter$new`
+## ------------------------------------------------
+
+reporter <- Reporter$new()
 
 
 ## ------------------------------------------------
@@ -244,35 +234,6 @@ Append one or more \code{ReportCard} objects to the \code{Reporter}.
 \subsection{Returns}{
 \code{self}, invisibly.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-library(rtables)
-
-card1 <- ReportCard$new()
-
-card1$append_text("Header 2 text", "header2")
-card1$append_text("A paragraph of default text", "header2")
-card1$append_plot(
-  ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
-
-card2 <- ReportCard$new()
-
-card2$append_text("Header 2 text", "header2")
-card2$append_text("A paragraph of default text", "header2")
-lyt <- analyze(split_rows_by(basic_table(), "Day"), "Ozone", afun = mean)
-table_res2 <- build_table(lyt, airquality)
-card2$append_table(table_res2)
-card2$append_table(iris)
-
-reporter <- Reporter$new()
-reporter$append_cards(list(card1, card2))
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Reporter-get_cards"></a>}}
@@ -286,36 +247,6 @@ Retrieves all \code{ReportCard} objects contained in the \code{Reporter}.
 \subsection{Returns}{
 A (\code{list}) of \code{\link{ReportCard}} objects.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-library(rtables)
-
-card1 <- ReportCard$new()
-
-card1$append_text("Header 2 text", "header2")
-card1$append_text("A paragraph of default text", "header2")
-card1$append_plot(
- ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
-
-card2 <- ReportCard$new()
-
-card2$append_text("Header 2 text", "header2")
-card2$append_text("A paragraph of default text", "header2")
-lyt <- analyze(split_rows_by(basic_table(), "Day"), "Ozone", afun = mean)
-table_res2 <- build_table(lyt, airquality)
-card2$append_table(table_res2)
-card2$append_table(iris)
-
-reporter <- Reporter$new()
-reporter$append_cards(list(card1, card2))
-reporter$get_cards()
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Reporter-get_blocks"></a>}}
@@ -337,37 +268,6 @@ Default is a \code{NewpageBlock$new()}object.}
 \subsection{Returns}{
 \code{list()} list of \code{TableBlock}, \code{TextBlock}, \code{PictureBlock} and \code{NewpageBlock}.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{library(ggplot2)
-library(rtables)
-
-card1 <- ReportCard$new()
-
-card1$append_text("Header 2 text", "header2")
-card1$append_text("A paragraph of default text", "header2")
-card1$append_plot(
- ggplot(iris, aes(x = Petal.Length)) + geom_histogram()
-)
-
-card2 <- ReportCard$new()
-
-card2$append_text("Header 2 text", "header2")
-card2$append_text("A paragraph of default text", "header2")
-lyt <- analyze(split_rows_by(basic_table(), "Day"), "Ozone", afun = mean)
-table_res2 <- build_table(lyt, airquality)
-card2$append_table(table_res2)
-card2$append_table(iris)
-
-reporter <- Reporter$new()
-reporter$append_cards(list(card1, card2))
-reporter$get_blocks()
-
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Reporter-reset"></a>}}

--- a/tests/testthat/test-DownloadReportModule.R
+++ b/tests/testthat/test-DownloadReportModule.R
@@ -1,3 +1,5 @@
+testthat::skip_if_not_installed("ggplot2")
+
 card1 <- ReportCard$new()
 card1$append_text("Header 2 text", "header2")
 card1$append_text("A paragraph of default text", "header2")

--- a/tests/testthat/test-LoadReporterModule.R
+++ b/tests/testthat/test-LoadReporterModule.R
@@ -1,4 +1,6 @@
 testthat::test_that("report_load_srv - loading reporter restores saved content", {
+  testthat::skip_if_not_installed("ggplot2")
+
   reporter <- Reporter$new()
   reporter$set_id("xyz")
   card <- teal.reporter::ReportCard$new()

--- a/tests/testthat/test-PictureBlock.R
+++ b/tests/testthat/test-PictureBlock.R
@@ -11,6 +11,8 @@ testthat::test_that("new returns an object of type PictureBlock", {
 
 # set_content
 testthat::test_that("set_content accepts a plot object", {
+  testthat::skip_if_not_installed("ggplot2")
+
   block <- PictureBlock$new()
   testthat::expect_no_error(
     block$set_content(ggplot2::ggplot(iris))
@@ -26,6 +28,8 @@ testthat::test_that("set_content asserts the argument is a plot", {
 })
 
 testthat::test_that("set_content returns the PictureBlock object", {
+  testthat::skip_if_not_installed("ggplot2")
+
   block <- PictureBlock$new()
   testthat::expect_identical(
     block$set_content(ggplot2::ggplot(iris)),
@@ -34,6 +38,8 @@ testthat::test_that("set_content returns the PictureBlock object", {
 })
 
 testthat::test_that("set_content catches a file with the 600x800 size", {
+  testthat::skip_if_not_installed("ggplot2")
+
   block <- PictureBlock$new()
   testthat::expect_equal(
     dim(png::readPNG(block$set_content(ggplot2::ggplot(iris))$get_content()))[c(1, 2)],
@@ -42,6 +48,8 @@ testthat::test_that("set_content catches a file with the 600x800 size", {
 })
 
 testthat::test_that("set_content catches a file with a custom size", {
+  testthat::skip_if_not_installed("ggplot2")
+
   block <- PictureBlock$new()
   testthat::expect_equal(
     dim(png::readPNG(block$set_dim(c(1000L, 100L))$set_content(ggplot2::ggplot(iris))$get_content()))[c(1, 2)],
@@ -128,12 +136,16 @@ testthat::test_that("set_content raises error if the content is not of the suppo
 })
 
 testthat::test_that("set_content accepts a `ggplot` object", {
+  testthat::skip_if_not_installed("ggplot2")
+
   testthat::expect_no_error(
     PictureBlock$new()$set_content(ggplot2::ggplot(iris))
   )
 })
 
 testthat::test_that("set_content accepts a `grob` object", {
+  testthat::skip_if_not_installed("ggplot2")
+
   testthat::expect_no_error(
     PictureBlock$new()$set_content(ggplot2::ggplotGrob(ggplot2::ggplot(iris)))
   )
@@ -147,6 +159,8 @@ testthat::test_that("set_content accepts a `trellis` object", {
 
 # to_list
 testthat::test_that("to_list returns a named list with a one field, a proper path", {
+  testthat::skip_if_not_installed("ggplot2")
+
   pblock <- PictureBlock$new()$set_content(ggplot2::ggplot(iris))
   temp_dir <- tempdir()
   testthat::expect_identical(
@@ -157,6 +171,8 @@ testthat::test_that("to_list returns a named list with a one field, a proper pat
 
 # from_list
 testthat::test_that("from_list after to_list to save and retrive", {
+  testthat::skip_if_not_installed("ggplot2")
+
   pblock <- PictureBlock$new()$set_content(ggplot2::ggplot(iris))
   temp_dir <- tempdir()
   testthat::expect_identical(

--- a/tests/testthat/test-PreviewerReportModule.R
+++ b/tests/testthat/test-PreviewerReportModule.R
@@ -1,3 +1,4 @@
+testthat::skip_if_not_installed("ggplot2")
 card1 <- ReportCard$new()
 card1$append_text("Header 2 text", "header2")
 card1$append_text("A paragraph of default text", "header2")

--- a/tests/testthat/test-Renderer.R
+++ b/tests/testthat/test-Renderer.R
@@ -6,6 +6,8 @@ testthat::test_that("new returns an object of type Renderer", {
   testthat::expect_true(inherits(Renderer$new(), "Renderer"))
 })
 
+testthat::skip_if_not_installed("ggplot2")
+
 text_block1 <- TextBlock$new()$set_content("text")$set_style("header2")
 text_block2 <- TextBlock$new()$set_content("text")
 png_path <- system.file("img", "Rlogo.png", package = "png")

--- a/tests/testthat/test-ReportCard.R
+++ b/tests/testthat/test-ReportCard.R
@@ -35,17 +35,22 @@ testthat::test_that("append_table returns self", {
 })
 
 testthat::test_that("append_plot returns self", {
+  testthat::skip_if_not_installed("ggplot2")
+
   card <- ReportCard$new()
   testthat::expect_identical(card$append_plot(ggplot2::ggplot(iris)), card)
 })
 
 testthat::test_that("append_plot accepts a ggplot", {
+  testthat::skip_if_not_installed("ggplot2")
   testthat::expect_no_error(
     ReportCard$new()$append_plot(ggplot2::ggplot(iris))
   )
 })
 
 testthat::test_that("append_plot accepts a ggplot with a dim", {
+  testthat::skip_if_not_installed("ggplot2")
+
   testthat::expect_no_error(
     ReportCard$new()$append_plot(ggplot2::ggplot(iris), c(1000L, 100L))
   )
@@ -65,18 +70,24 @@ testthat::test_that("append_rcode returns self", {
 })
 
 testthat::test_that("get_content returns a list of ContentBlock objects", {
+  testthat::skip_if_not_installed("ggplot2")
+
   card <- ReportCard$new()
   card$append_text("test")$append_plot(ggplot2::ggplot(iris))$append_metadata("SRC", "A <- plot()")
   testthat::expect_true(checkmate::test_list(card$get_content(), types = "ContentBlock"))
 })
 
 testthat::test_that("get_metadata returns a list of mixed objects", {
+  testthat::skip_if_not_installed("ggplot2")
+
   card <- ReportCard$new()
   card$append_metadata("sth", "test")$append_metadata("sth2", ggplot2::ggplot(iris))
   testthat::expect_false(checkmate::test_list(card$get_metadata(), types = "ContentBlock"))
 })
 
 testthat::test_that("get_metadata returns a named list", {
+  testthat::skip_if_not_installed("ggplot2")
+
   card <- ReportCard$new()
   card$append_metadata("sth", "test")$append_metadata("sth2", ggplot2::ggplot(iris))
   testthat::expect_equal(c("sth", "sth2"), names(card$get_metadata()))
@@ -126,6 +137,7 @@ testthat::test_that("append_metadata throws error if keys are duplicated", {
 
 
 testthat::test_that("The deep copy constructor copies the file in the content blocks", {
+  testthat::skip_if_not_installed("ggplot2")
   card <- ReportCard$new()
   card$append_text("test")$append_plot(ggplot2::ggplot(iris))$append_metadata("SRC", "A <- plot(1)")
   card_copy <- card$clone(deep = TRUE)
@@ -135,6 +147,8 @@ testthat::test_that("The deep copy constructor copies the file in the content bl
 })
 
 testthat::test_that("The deep copy constructor copies the non ContentBlock objects", {
+  testthat::skip_if_not_installed("ggplot2")
+
   card <- ReportCard$new()
   card$append_text("test")$append_plot(ggplot2::ggplot(iris))$append_metadata("SRC", "A <- plot(1)")
   card_copy <- card$clone(deep = TRUE)
@@ -152,6 +166,8 @@ testthat::test_that("setting and getting a name to the ReportCard", {
     character(0)
   )
 })
+
+testthat::skip_if_not_installed("ggplot2")
 
 card <- ReportCard$new()
 rcode <- "ggplot2::ggplot(iris, ggplot2::aes(x = Petal.Length)) + ggplot2::geom_histogram()"

--- a/tests/testthat/test-Reporter.R
+++ b/tests/testthat/test-Reporter.R
@@ -6,6 +6,8 @@ testthat::test_that("new returns an object of type Reporter", {
   testthat::expect_true(inherits(Reporter$new(), "Reporter"))
 })
 
+testthat::skip_if_not_installed("ggplot2")
+
 card1 <- ReportCard$new()
 
 card1$append_text("Header 2 text", "header2")

--- a/tests/testthat/test-ResetModule.R
+++ b/tests/testthat/test-ResetModule.R
@@ -1,3 +1,5 @@
+testthat::skip_if_not_installed("ggplot2")
+
 card_fun <- function(card = ReportCard$new(), comment = NULL) {
   card$append_text("Header 2 text", "header2")
   card$append_text("A paragraph of default text", "header2")

--- a/tests/testthat/test-SimpleReporter.R
+++ b/tests/testthat/test-SimpleReporter.R
@@ -1,3 +1,5 @@
+testthat::skip_if_not_installed("ggplot2")
+
 card_fun0 <- function(card = ReportCard$new()) {
   card$append_text("Header 2 text", "header2")
   card$append_text("A paragraph of default text", "header2")

--- a/vignettes/previewerReporter.Rmd
+++ b/vignettes/previewerReporter.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-The Report previewer is an advanced shiny module designed for visualization, editing, and downloading of report cards. 
+The Report previewer is an advanced shiny module designed for visualization, editing, and downloading of report cards.
 It extended the base modules introduced in the `simpleReporter` vignette, enhancing interactivity and user engagement with report content.
 
 
@@ -19,10 +19,10 @@ The five essential steps for implementing the report previewer include integrati
 4. Create the report card function with two optional arguments: `card` and `comment`.
 This function must return a `ReportCard` object.
 The `ReportCard` object should be built step by step, assuming that it is empty at the beginning.
-   - If the `comment` argument is provided, it should be added to the card. 
-   If not, it should be added automatically at the end of the card. 
-   - If the `card` argument is provided, the `ReportCard` instance should be automatically created for the user. 
-   If not, the function should create the card itself. 
+   - If the `comment` argument is provided, it should be added to the card.
+   If not, it should be added automatically at the end of the card.
+   - If the `card` argument is provided, the `ReportCard` instance should be automatically created for the user.
+   If not, the function should create the card itself.
 *Please note that the document page's design is up to the developer's imagination.*
 5. Invoke the servers with the `Reporter` instance and the function to create the `ReportCard` instance.
 
@@ -30,7 +30,7 @@ The code added to introduce the reporter is wrapped in the `### REPORTER` code b
 
 First, load the required packages:
 
-```{r message = FALSE}
+```{r, message = FALSE, eval=requireNamespace("ggplot2") && requireNamespace("DT")}
 library(shiny)
 library(teal.reporter)
 library(ggplot2)
@@ -41,7 +41,7 @@ library(bslib)
 
 A basic `shiny` app with the previewer module:
 
-```{r}
+```{r, eval=requireNamespace("ggplot2")}
 ui <- fluidPage(
   # please, specify specific bootstrap version and theme
   theme = bs_theme(version = "4"),

--- a/vignettes/simpleReporter.Rmd
+++ b/vignettes/simpleReporter.Rmd
@@ -30,10 +30,10 @@ The implementation should consist of 4 steps:
 4. Create the report card function with two optional arguments: `card` and `comment`.
 This function must return a `ReportCard` object.
 The `ReportCard` object should be built step by step, assuming that it is empty at the beginning.
-   - If the `comment` argument is provided, it should be added to the card. 
-   If not, it should be added automatically at the end of the card. 
-   - If the `card` argument is provided, the `ReportCard` instance should be automatically created for the user. 
-   If not, the function should create the card itself. 
+   - If the `comment` argument is provided, it should be added to the card.
+   If not, it should be added automatically at the end of the card.
+   - If the `card` argument is provided, the `ReportCard` instance should be automatically created for the user.
+   If not, the function should create the card itself.
 *Please note that the document page's design is up to the developer's imagination.*
 4. Invoke the servers with the `Reporter` instance and the function to create the `ReportCard` instance.
 
@@ -41,7 +41,7 @@ The code added to introduce the reporter is wrapped in the `### REPORTER` code b
 
 First, load the required packages:
 
-```{r message = FALSE}
+```{r message = FALSE, eval=requireNamespace("ggplot2")}
 library(shiny)
 library(teal.reporter)
 library(ggplot2)
@@ -50,7 +50,7 @@ library(rtables)
 
 Simple reporter `shiny` app with separate modules for each button:
 
-```{r}
+```{r, eval=requireNamespace("ggplot2")}
 ui <- fluidPage(
   titlePanel(""),
   sidebarLayout(
@@ -147,7 +147,7 @@ if (interactive()) shinyApp(ui = ui, server = server)
 
 Simple reporter `shiny` app with combined buttons modules:
 
-```{r}
+```{r, eval=requireNamespace("ggplot2")}
 ui <- fluidPage(
   titlePanel(""),
   sidebarLayout(

--- a/vignettes/teal-reporter-blocks-overview.Rmd
+++ b/vignettes/teal-reporter-blocks-overview.Rmd
@@ -8,11 +8,11 @@ vignette: >
 ---
 
 ## Overview of Content Blocks
-This document serves as a comprehensive guide to the various types of content blocks available in the `teal.reporter`. 
+This document serves as a comprehensive guide to the various types of content blocks available in the `teal.reporter`.
 These blocks allow users to structure and customize reports.
 
 ## Table: Content Blocks in `teal.reporter`
-The following table outlines the different blocks that can be included in a `ReportCard`, 
+The following table outlines the different blocks that can be included in a `ReportCard`,
 along with descriptions and usage examples:
 
 | **Block Type** | **Description** | **Usage Example** |
@@ -25,7 +25,7 @@ along with descriptions and usage examples:
   | **`FileBlock`** | Manages file-based content, ensuring proper file handling. | `report_card$append_content(<FileBlock>)` |
   | **`TableBlock`** | Holds and displays tabular data. | `report_card$append_table(<table>)` |
   | **`PictureBlock`** | Contains graphical content from classes like `ggplot`, `grob`, `trellis`, and `Heatmap`. | `report_card$append_plot(<plot>)` |
-  
+
  These blocks form the building blocks of a `ReportCard`, each serving a specific function that contributes to the overall layout and content of the report. The `ReportCard` object utilizes `append_*` methods to integrate various blocks such as `TextBlock`, `PictureBlock`, `RcodeBlock`, and `TableBlock`.
 
 The following diagram illustrates the inheritance relationship between the different blocks:
@@ -102,7 +102,7 @@ getOption("teal.reporter.global_knitr")
 ## Example Report Using Multiple Content Blocks
 Below is a complete example demonstrating how to create a report combining various content blocks:
 
-```{r}
+```{r, eval=requireNamespace("ggplot2")}
 library(ggplot2)
 
 report_card <- ReportCard$new()


### PR DESCRIPTION
Fixes #284 

Small note, I ended up using `testthat::skip_if_not_installed("ggplot2")` at the beginning of several unit test files (e.g., `test-DownloadReportModule.R`, `test-LoadReporterModule.R`, etc.) because they depend on `ggplot2` at the start of the test. 

I don't think this update will affect our code coverage since code coverage is done using a different workflow (`Check`) which I believe will install all dependencies, including `ggplot2`.