### PR TITLE
Add `rtables.officer` as a dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
           - zip
           - rlistings
           - rtables
+          - rtables.officer
       - id: spell-check
         name: Check spelling with `spelling`
         exclude: >

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Imports:
     R6,
     rlistings (>= 0.2.8),
     rmarkdown (>= 2.23),
-    rtables (>= 0.6.6),
+    rtables (>= 0.6.10.9004),
+    rtables.officer (>= 0.0.1.9005),
     shiny (>= 1.6.0),
     shinybusy (>= 0.3.2),
     shinyWidgets (>= 0.5.1),
@@ -56,9 +57,10 @@ RdMacros:
 Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,
     davidgohel/flextable, rstudio/htmltools, yihui/knitr, r-lib/lifecycle,
     r-lib/R6, insightsengineering/rlistings, rstudio/rmarkdown,
-    insightsengineering/rtables, rstudio/shiny, dreamRs/shinybusy,
-    dreamRs/shinyWidgets, yaml=vubiostat/r-yaml, r-lib/zip, rstudio/DT,
-    yihui/formatR, insightsengineering/formatters, tidyverse/ggplot2,
+    insightsengineering/rtables, insightsengineering/rtables.officer,
+    rstudio/shiny, dreamRs/shinybusy, dreamRs/shinyWidgets,
+    yaml=vubiostat/r-yaml, r-lib/zip, rstudio/DT, yihui/formatR,
+    insightsengineering/formatters, tidyverse/ggplot2,
     deepayan/lattice, cran/png, r-lib/testthat, rstudio/tinytex,
     r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate

--- a/R/utils.R
+++ b/R/utils.R
@@ -125,7 +125,7 @@ panel_item <- function(title, ..., collapsed = TRUE, input_id = NULL) {
 #' @keywords internal
 to_flextable <- function(content) {
   if (inherits(content, c("rtables", "TableTree", "ElementaryTable"))) {
-    ft <- rtables::tt_to_flextable(content)
+    ft <- rtables.officer::tt_to_flextable(content)
   } else if (inherits(content, "listing_df")) {
     mf <- rlistings::matrix_form(content)
     nr_header <- attr(mf, "nrow_header")
@@ -140,9 +140,9 @@ to_flextable <- function(content) {
     rtables::main_footer(ft) <- mf$main_footer
     rtables::prov_footer(ft) <- mf$prov_footer
     rtables::header_section_div(ft) <- mf$header_section_div
-    ft <- rtables::tt_to_flextable(ft, total_width = c(grDevices::pdf.options()$width - 1))
+    ft <- rtables.officer::tt_to_flextable(ft, total_width = c(grDevices::pdf.options()$width - 1))
   } else if (inherits(content, "data.frame")) {
-    ft <- rtables::tt_to_flextable(
+    ft <- rtables.officer::tt_to_flextable(
       rtables::df_to_tt(content)
     )
   } else {

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -25,6 +25,9 @@ upstream_repos:
   insightsengineering/rtables:
     repo: insightsengineering/rtables
     host: https://github.com
+  insightsengineering/rtables.officer:
+    repo: insightsengineering/rtables.officer
+    host: https://github.com
   insightsengineering/rlistings:
     repo: insightsengineering/rlistings
     host: https://github.com


### PR DESCRIPTION
Changes:
1. Updates the `rtables` version
2. Adds `rtables.officer` as a new dependency

Note that this blocks CRAN release of `teal.reporter` untill the `rtables.officer` and `rtables` is released.