### PR TITLE
upgrade formatters and rlistings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
 Suggests:
     DT (>= 0.13),
     formatR (>= 1.5),
-    formatters,
+    formatters (>= 0.5.10),
     ggplot2 (>= 3.4.3),
     lattice (>= 0.18-4),
     png,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     knitr (>= 1.42),
     lifecycle (>= 0.2.0),
     R6,
-    rlistings (>= 0.2.8),
+    rlistings (>= 0.2.10),
     rmarkdown (>= 2.23),
     rtables (>= 0.6.10.9004),
     rtables.officer (>= 0.0.1.9005),


### PR DESCRIPTION
There is also one more tests failing on dependency tests due to formatters+rlistings combination

```r
 ── Error ('test-utils.R:25'): to_flextable: supported class `listing_df` ───────
  Error in `FUN(X[[i]], ...)`: argument "fontspec" is missing, with no default
  Backtrace:
       ▆
    1. └─teal.reporter:::to_flextable(lsting) at test-utils.R:25:3
    2.   ├─rlistings::matrix_form(content)
    3.   └─rlistings::matrix_form(content)
    4.     └─rlistings (local) .local(obj, indent_rownames, expand_newlines)
    5.       ├─formatters::MatrixPrintForm(...)
    6.       │ └─base::structure(...)
    7.       ├─formatters::make_row_df(obj)
    8.       └─rlistings::make_row_df(obj)
    9.         └─rlistings (local) .local(...)
   10.           ├─rlistings:::vec_nlines(tt[[col]], max_width = colwidths[col])
   11.           └─rlistings:::vec_nlines(tt[[col]], max_width = colwidths[col])
   12.             ├─base::unlist(lapply(format_colvector(colvec = vec), nlines, max_width = max_width))
   13.             └─base::lapply(format_colvector(colvec = vec), nlines, max_width = max_width)
   14.               ├─formatters (local) FUN(X[[i]], ...)
   15.               └─formatters (local) FUN(X[[i]], ...)
   16.                 └─base::vapply(...)
   17.                   └─formatters (local) FUN(X[[i]], ...)
   18.                     └─formatters::wrap_txt(xi, max_width, fontspec = fontspec)
   19.                       └─formatters::open_font_dev(fontspec)
```