### PR TITLE
Fixes 1-card problem in refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,10 @@ repos:
           - R6
           - rmarkdown
           - shiny
+          - shinyjs
           - shinybusy
           - shinyWidgets
+          - sortable
           - yaml
           - zip
           - rlistings

--- a/R/Editor.R
+++ b/R/Editor.R
@@ -73,7 +73,9 @@ editor_srv.ReportDocument <- function(id, x, x_reactive) {
         ),
         1
       )
-      x_reactive(c(x_reactive(), stats::setNames(list(""), new_name)))
+      x_reactive(
+        modifyList(x_reactive(), stats::setNames(list(""), new_name)) # Preserve attributes
+      )
     })
   })
 }

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -129,11 +129,11 @@ reporter_previewer_srv <- function(id,
     insert_cards <- shiny::reactiveVal()
     remove_cards <- shiny::reactiveVal()
     shiny::observeEvent(reporter$get_reactive_add_card(), {
-      reporter_hashes <- vapply(reporter$get_cards(), attr, character(1L), which = "hash")
-      current_hashes <- vapply(current_cards(), attr, character(1L), which = "hash")
+      reporter_ids <- vapply(reporter$get_cards(), attr, character(1L), which = "id")
+      current_ids <- vapply(current_cards(), attr, character(1L), which = "id")
 
-      to_add <- reporter$get_cards()[!reporter_hashes %in% current_hashes]
-      to_remove <- current_cards()[!current_hashes %in% reporter_hashes]
+      to_add <- reporter$get_cards()[!reporter_ids %in% current_ids]
+      to_remove <- current_cards()[!current_ids %in% reporter_ids]
       if (length(to_add)) insert_cards(to_add)
       if (length(to_remove)) remove_cards(to_remove)
       current_cards(reporter$get_cards())

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -129,8 +129,14 @@ reporter_previewer_srv <- function(id,
     insert_cards <- shiny::reactiveVal()
     remove_cards <- shiny::reactiveVal()
     shiny::observeEvent(reporter$get_reactive_add_card(), {
-      to_add <- reporter$get_cards()[!reporter$get_cards() %in% current_cards()] # because setdiff loses names
-      to_remove <- current_cards()[!current_cards() %in% reporter$get_cards()]
+      reporter_hashes <- vapply(reporter$get_cards(), attr, character(1L), which = "hash")
+      current_hashes <- vapply(current_cards(), attr, character(1L), which = "hash")
+
+      logger::log_fatal("current_hashes: {current_hashes}")
+      logger::log_fatal("reporter_hashes: {reporter_hashes}")
+
+      to_add <- reporter$get_cards()[!reporter_hashes %in% current_hashes]
+      to_remove <- current_cards()[!current_hashes %in% reporter_hashes]
       if (length(to_add)) insert_cards(to_add)
       if (length(to_remove)) remove_cards(to_remove)
       current_cards(reporter$get_cards())

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -142,12 +142,13 @@ reporter_previewer_srv <- function(id,
     shiny::observeEvent(insert_cards(), {
       cards <- insert_cards()
       lapply(names(cards), function(card_name) {
+        card_id <- attr(cards[[card_name]], "id", exact = TRUE)
         bslib::accordion_panel_insert(
           id = "reporter_cards",
-          reporter_previewer_card_ui(id = session$ns(card_name), card_name = card_name)
+          reporter_previewer_card_ui(id = session$ns(card_id), card_name = card_name)
         )
         reporter_previewer_card_srv(
-          id = card_name,
+          id = card_id,
           reporter = reporter,
           card = cards[[card_name]]
         )

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -132,9 +132,6 @@ reporter_previewer_srv <- function(id,
       reporter_hashes <- vapply(reporter$get_cards(), attr, character(1L), which = "hash")
       current_hashes <- vapply(current_cards(), attr, character(1L), which = "hash")
 
-      logger::log_fatal("current_hashes: {current_hashes}")
-      logger::log_fatal("reporter_hashes: {reporter_hashes}")
-
       to_add <- reporter$get_cards()[!reporter_hashes %in% current_hashes]
       to_remove <- current_cards()[!current_hashes %in% reporter_hashes]
       if (length(to_add)) insert_cards(to_add)

--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -449,9 +449,12 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     metadata = list(),
     reactive_add_card = NULL,
     template = NULL,
+    # @description Update the attributes of a card and generates unique hash
+    # @param card the card to be updated
+    # @param label the label to be set
     update_attributes = function(card, label) {
       attr(card, "label") <- label
-      attr(card, "hash") <- rlang::hash(card)
+      attr(card, "id") <- rlang::hash(list(card, Sys.time()))
       card
     },
     # @description The copy constructor.

--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -20,7 +20,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #'
     initialize = function() {
       private$cards <- list()
-      private$reactive_add_card <- shiny::reactiveVal(0)
+      private$reactive_add_card <- shiny::reactiveVal(NULL)
       invisible(self)
     },
     #' @description Append one or more `ReportCard` or `ReportDocument` objects to the `Reporter`.
@@ -44,16 +44,15 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #' reporter <- Reporter$new()
     #' reporter$append_cards(list(card1, doc1))
     append_cards = function(cards) {
-      checkmate::assert_list(cards, c("ReportCard", "ReportDocument"))
+      checkmate::assert_list(cards, types = c("ReportCard", "ReportDocument"))
       rcs <- which(vapply(cards, inherits, logical(1), "ReportCard"))
+      names(cards)[rcs] <- sapply(cards[rcs], function(card) card$get_name())
+
       rds <- which(vapply(cards, inherits, logical(1), "ReportDocument"))
-      if (length(rcs)) {
-        names(cards)[rcs] <- sapply(cards[rcs], function(card) card$get_name())
-      }
       if (length(rds) && !is.null(self$get_template())) {
-        template_fun <- self$get_template()
-        cards[rds] <- lapply(cards[rds], function(doc) template_fun(doc))
+        cards[rds] <- lapply(cards[rds], self$get_template())
       }
+      cards <- mapply(private$update_attributes, card = cards, label = names(cards), SIMPLIFY = FALSE)
       private$cards <- append(private$cards, cards)
       shiny::isolate(private$reactive_add_card(length(private$cards)))
       invisible(self)
@@ -137,7 +136,8 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
       if (is.character(id)) {
         id <- which(names(private$cards) == id)
       }
-      private$cards[[id]] <- card
+      new_card <- private$update_attributes(card(), id)
+      private$cards[[id]] <- new_card
       private$reactive_add_card(length(private$cards))
       invisible(self)
     },
@@ -166,9 +166,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #' reporter <- Reporter$new()
     #' reporter$append_cards(list(card1, card2))
     #' reporter$get_cards()
-    get_cards = function() {
-      private$cards
-    },
+    get_cards = function() private$cards,
     #' @description Compiles and returns all content blocks from the `ReportCard` and `ReportDocument` objects in the `Reporter`.
     #' @param sep An optional separator to insert between each content block.
     #' Default is a `NewpageBlock$new()` object.
@@ -223,7 +221,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     reset = function() {
       private$cards <- list()
       private$metadata <- list()
-      private$reactive_add_card(0)
+      private$reactive_add_card(NULL)
       invisible(self)
     },
     #' @description Removes specific `ReportCard` or `ReportDocument` objects from the `Reporter` by their indices.
@@ -255,9 +253,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #' library(shiny)
     #'
     #' isolate(Reporter$new()$get_reactive_add_card())
-    get_reactive_add_card = function() {
-      private$reactive_add_card()
-    },
+    get_reactive_add_card = function() private$reactive_add_card(),
     #' @description Get the metadata associated with this `Reporter`.
     #'
     #' @return `named list` of metadata to be appended.
@@ -265,9 +261,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     #' reporter <- Reporter$new()$append_metadata(list(sth = "sth"))
     #' reporter$get_metadata()
     #'
-    get_metadata = function() {
-      private$metadata
-    },
+    get_metadata = function() private$metadata,
     #' @description Appends metadata to this `Reporter`.
     #'
     #' @param meta (`named list`) of metadata to be appended.
@@ -425,9 +419,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     },
     #' @description Get the `Reporter` id
     #' @return `character(1)` the `Reporter` id.
-    get_id = function() {
-      private$id
-    },
+    get_id = function() private$id,
     #' @description Set template function for `ReportDocument`
     #' Set a function that is called on every report content (of class `ReportDocument`) added through `$append_cards`
     #' @param template (`function`) a template function.
@@ -450,9 +442,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     },
     #' @description Get the `Reporter` template
     #' @return a template `function`.
-    get_template = function() {
-      private$template
-    }
+    get_template = function() private$template
   ),
   private = list(
     id = "",
@@ -460,6 +450,11 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     metadata = list(),
     reactive_add_card = NULL,
     template = NULL,
+    update_attributes = function(card, label) {
+      attr(card, "label") <- label
+      attr(card, "hash") <- rlang::hash(card)
+      card
+    },
     # @description The copy constructor.
     #
     # @param name the name of the field

--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -454,7 +454,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
     # @param label the label to be set
     update_attributes = function(card, label) {
       attr(card, "label") <- label
-      attr(card, "id") <- rlang::hash(list(card, Sys.time()))
+      attr(card, "id") <- sprintf("card_%s", substr(rlang::hash(list(card, Sys.time())), 1, 8))
       card
     },
     # @description The copy constructor.

--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -136,8 +136,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
       if (is.character(id)) {
         id <- which(names(private$cards) == id)
       }
-      new_card <- private$update_attributes(card(), id)
-      private$cards[[id]] <- new_card
+      private$cards[[id]] <- card()
       private$reactive_add_card(length(private$cards))
       invisible(self)
     },


### PR DESCRIPTION
# Pull Request

Fixes #324

- Uses hash of card to uniquely identify card (with timestamp to further ensure uniqueness)
    - I don't think it warrants using `{uuid}` package
- Use this hash as shiny module name to avoid invalid ids
- Saves label and id as attributes of `ReportDocument`