### PR TITLE
Merge metadata of teal cards in `c.teal_card`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,5 @@
 linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
-  cyclocomp_linter = NULL,
   object_usage_linter = NULL,
   indentation_linter = NULL
   )

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -90,13 +90,14 @@ c.teal_card <- function(...) {
   structure(
     Reduce(
       f = function(u, v) {
-        if (!inherits(v, "teal_card")) v <- as.teal_card(v)
-        result <- append(u, v)
-        attributes(result) <- modifyList(attributes(u) %||% list(), attributes(v))
+        v <- as.teal_card(v)
+        attrs <- utils::modifyList(attributes(u) %||% list(), attributes(v))
+        result <- c(unclass(u), v)
+        attributes(result) <- attrs
         result
       },
-      x = dots[-1],
-      init = unclass(dots[[1]]) # unclass to avoid infinite recursion
+      x = dots,
+      init = list()
     ),
     class = "teal_card"
   )

--- a/man/metadata-set.Rd
+++ b/man/metadata-set.Rd
@@ -6,9 +6,9 @@
 \alias{metadata<-.ReportCard}
 \title{Set metadata for a \code{teal_card} or \code{ReportCard}}
 \usage{
-metadata(object, which) <- value
+metadata(object, which = NULL) <- value
 
-\method{metadata}{teal_card}(object, which) <- value
+\method{metadata}{teal_card}(object, which = NULL) <- value
 
 \method{metadata}{ReportCard}(object, which) <- value
 }

--- a/tests/testthat/test-teal_report-eval_code.R
+++ b/tests/testthat/test-teal_report-eval_code.R
@@ -1,7 +1,13 @@
 testthat::describe("keep_output stores the objects in teal_card", {
   it("using eval_code and explicit reference", {
-    q <- eval_code(teal_report(), "a <- 1L;b <-2L;c<- 3L", keep_output = "b")
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q))]], 2L)
+    q <- eval_code(teal_report(), "a <- 1L;b <- 2L;c <- 3L", keep_output = "b")
+    testthat::expect_identical(
+      teal_card(q),
+      teal_card(
+        code_chunk("a <- 1L;b <- 2L;c <- 3L"),
+        structure(2L, class = c("chunk_output", "integer"))
+      )
+    )
   })
 
   it("using within and explicit reference", {
@@ -11,19 +17,34 @@ testthat::describe("keep_output stores the objects in teal_card", {
         b <- 2L
         c <- 3L
       },
-      keep_output = "a"
+      keep_output = "b"
     )
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q))]], 1L)
+    testthat::expect_identical(
+      teal_card(q),
+      teal_card(
+        code_chunk("a <- 1L\nb <- 2L\nc <- 3L"),
+        structure(2L, class = c("chunk_output", "integer"))
+      )
+    )
   })
 
   it("with multiple explicit object references", {
-    q <- eval_code(teal_report(), "a <- 1L;b <- 2L;c <- 3L", keep_output = c("c", "a"))
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q)) - 1]], 3L)
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q))]], 1L)
+    q <- eval_code(teal_report(), "a <- 1L;b <- 2L;c <- 3L", keep_output = c("a", "b"))
+    testthat::expect_identical(
+      teal_card(q),
+      teal_card(
+        code_chunk("a <- 1L;b <- 2L;c <- 3L"),
+        structure(1L, class = c("chunk_output", "integer")),
+        structure(2L, class = c("chunk_output", "integer"))
+      )
+    )
   })
 
   it("without explicit reference returing none", {
-    q <- eval_code(teal_report(), "a <- 1L;z <- 2L;c <- 3L", keep_output = character(0L))
-    testthat::expect_equal(teal_card(q)[-1], teal_card())
+    q <- eval_code(teal_report(), "a <- 1L;b <- 2L;c <- 3L", keep_output = character(0L))
+    testthat::expect_identical(
+      teal_card(q),
+      teal_card(code_chunk("a <- 1L;b <- 2L;c <- 3L"))
+    )
   })
 })


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #340

### Changes description

- Merge attributes of `teal_card` object
- Improve on `as.teal_card` for a better conversion from `list` -> `teal_card`
- Only plain lists should be considered as `teal_card` compatible.
    - Specifically, only those that `class(obj)` is identical to `list` (`is.list` or `inherits(obj, "list")` is not enough)
        - why not enough? because of `ggplot` and other custom lists just like `join_keys` would be merged.

### Consideration

- Should we keep the same attributes of the original object in `as.teal_card`?
