### PR TITLE
Use evaluate

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,5 @@
 linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
-  cyclocomp_linter = NULL,
   object_usage_linter = NULL,
   indentation_linter = NULL
   )

--- a/R/teal_report-eval_code.R
+++ b/R/teal_report-eval_code.R
@@ -25,7 +25,13 @@ setMethod(
     new_blocks <- Reduce(
       function(items, code_elem) {
         this_chunk <- do.call(code_chunk, c(list(code = code_elem), code_block_opts))
-        this_outs <- lapply(attr(code_elem, "outputs"), function(x) structure(x, class = c("chunk_output", class(x))))
+        this_outs <- Filter( # intentionally remove warnings,messages from the generated report
+          function(x) !inherits(x, "condition"),
+          lapply(
+            attr(code_elem, "outputs"),
+            function(x) structure(x, class = c("chunk_output", class(x)))
+          )
+        )
         c(items, list(this_chunk), this_outs)
       },
       init = list(),

--- a/man/eval_code-teal_report-method.Rd
+++ b/man/eval_code-teal_report-method.Rd
@@ -4,7 +4,7 @@
 \alias{eval_code,teal_report-method}
 \title{Evaluate code in \code{qenv}}
 \usage{
-\S4method{eval_code}{teal_report}(object, code, keep_output = NULL, code_block_opts = list(), ...)
+\S4method{eval_code}{teal_report}(object, code, code_block_opts = list(), ...)
 }
 \arguments{
 \item{object}{(\code{teal_report})}
@@ -12,10 +12,6 @@
 \item{code}{(\code{character}, \code{language} or \code{expression}) code to evaluate.
 It is possible to preserve original formatting of the \code{code} by providing a \code{character} or an
 \code{expression} being a result of \code{parse(keep.source = TRUE)}.}
-
-\item{keep_output}{(\code{character} or \code{NULL}) Names of output objects in the environment
-that are will be added in the card for the reporter.
-These are shown in the card via the \code{\link[tools:toHTML]{tools::toHTML()}} and \code{\link[=to_rmd]{to_rmd()}} implementations.}
 
 \item{code_block_opts}{(\code{list}) Additional options for the R code chunk in R Markdown.}
 

--- a/tests/testthat/test-teal_report-eval_code.R
+++ b/tests/testthat/test-teal_report-eval_code.R
@@ -24,6 +24,13 @@ testthat::describe("eval_code appends to teal_card", {
       )
     )
   })
+
+  it("code as code_chunk and condition is excluded from output", {
+    q <- eval_code(teal_report(), "warning('test')")
+    testthat::expect_identical(
+      teal_card(q),
+      c(teal_card(), code_chunk("a <- 1L"))
+  })
 })
 
 testthat::describe("within appends to teal_card", {
@@ -40,22 +47,6 @@ testthat::describe("within appends to teal_card", {
         code_chunk("a <- 1L"),
         code_chunk("b <- 2L"),
         code_chunk("c <- 3L")
-      )
-    )
-  })
-
-  it("code as code_chunk and its output as chunk_output", {
-    q <- within(teal_report(), {
-      a <- 1L
-      a
-    })
-    testthat::expect_identical(
-      teal_card(q),
-      c(
-        teal_card(),
-        code_chunk("a <- 1L"),
-        code_chunk("a"),
-        structure(1L, class = c("chunk_output", "integer"))
       )
     )
   })

--- a/tests/testthat/test-teal_report-eval_code.R
+++ b/tests/testthat/test-teal_report-eval_code.R
@@ -1,29 +1,62 @@
-testthat::describe("keep_output stores the objects in teal_card", {
-  it("using eval_code and explicit reference", {
-    q <- eval_code(teal_report(), "a <- 1L;b <-2L;c<- 3L", keep_output = "b")
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q))]], 2L)
-  })
-
-  it("using within and explicit reference", {
-    q <- within(teal_report(),
-      {
-        a <- 1L
-        b <- 2L
-        c <- 3L
-      },
-      keep_output = "a"
+testthat::describe("eval_code appends to teal_card", {
+  it("code as code_chunk", {
+    q <- eval_code(teal_report(), "a <- 1L;b <- 2L;c <- 3L")
+    testthat::expect_identical(
+      teal_card(q),
+      c(
+        teal_card(),
+        code_chunk("a <- 1L"),
+        code_chunk("b <- 2L"),
+        code_chunk("c <- 3L")
+      )
     )
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q))]], 1L)
   })
 
-  it("with multiple explicit object references", {
-    q <- eval_code(teal_report(), "a <- 1L;b <- 2L;c <- 3L", keep_output = c("c", "a"))
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q)) - 1]], 3L)
-    testthat::expect_equal(teal_card(q)[[length(teal_card(q))]], 1L)
+  it("code as code_chunk and its output as chunk_output", {
+    q <- eval_code(teal_report(), "a <- 1L;a")
+    testthat::expect_identical(
+      teal_card(q),
+      c(
+        teal_card(),
+        code_chunk("a <- 1L"),
+        code_chunk("a"),
+        structure(1L, class = c("chunk_output", "integer"))
+      )
+    )
+  })
+})
+
+testthat::describe("within appends to teal_card", {
+  it("code as code_chunk", {
+    q <- within(teal_report(), {
+      a <- 1L
+      b <- 2L
+      c <- 3L
+    })
+    testthat::expect_identical(
+      teal_card(q),
+      c(
+        teal_card(),
+        code_chunk("a <- 1L"),
+        code_chunk("b <- 2L"),
+        code_chunk("c <- 3L")
+      )
+    )
   })
 
-  it("without explicit reference returing none", {
-    q <- eval_code(teal_report(), "a <- 1L;z <- 2L;c <- 3L", keep_output = character(0L))
-    testthat::expect_equal(teal_card(q)[-1], teal_card())
+  it("code as code_chunk and its output as chunk_output", {
+    q <- within(teal_report(), {
+      a <- 1L
+      a
+    })
+    testthat::expect_identical(
+      teal_card(q),
+      c(
+        teal_card(),
+        code_chunk("a <- 1L"),
+        code_chunk("a"),
+        structure(1L, class = c("chunk_output", "integer"))
+      )
+    )
   })
 })


### PR DESCRIPTION
Followup to https://github.com/insightsengineering/teal.code/pull/258

- eval_code adds `attr(code, "outputs")` to the `teal_card` but skips the warnings and messages (conditions).