### PR TITLE
Bump version of shiny to support `bslib` and align with `teal`'s min `shiny` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     rmarkdown (>= 2.23),
     rtables (>= 0.6.11),
     rtables.officer (>= 0.0.2),
-    shiny (>= 1.6.0),
+    shiny (>= 1.8.1),
     shinybusy (>= 0.3.2),
     shinyjs,
     shinyWidgets (>= 0.5.1),


### PR DESCRIPTION
Bump shiny version as per the discussion [here](https://github.com/insightsengineering/teal.widgets/pull/312#discussion_r2250985703)