### PR TITLE
Improves on error message on loading reporter 

### DIFF
--- a/R/LoadReporterModule.R
+++ b/R/LoadReporterModule.R
@@ -134,6 +134,12 @@ load_json_report <- function(reporter, zip_path, filename) {
       }
     )
   } else {
-    shiny::showNotification("Failed to load the Reporter file.", type = "error")
+    shiny::showNotification(
+      paste(
+        "Failed to load the Reporter file.",
+        "Please make sure that the filename starts with `reporter_`."
+      ), 
+      type = "error"
+    )
   }
 }

--- a/R/LoadReporterModule.R
+++ b/R/LoadReporterModule.R
@@ -138,7 +138,7 @@ load_json_report <- function(reporter, zip_path, filename) {
       paste(
         "Failed to load the Reporter file.",
         "Please make sure that the filename starts with `reporter_`."
-      ), 
+      ),
       type = "error"
     )
   }

--- a/R/LoadReporterModule.R
+++ b/R/LoadReporterModule.R
@@ -137,7 +137,7 @@ load_json_report <- function(reporter, zip_path, filename) {
     shiny::showNotification(
       paste(
         "Failed to load the Reporter file.",
-        "Please make sure that the filename starts with `reporter_`."
+        "Please make sure that the filename starts with `report_`."
       ),
       type = "error"
     )


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

- Fixes https://github.com/insightsengineering/teal.reporter/issues/365

### Changes description

- Improves error message as users may have renamed the file

<img width="993" height="273" alt="2025-08-07_15-22" src="https://github.com/user-attachments/assets/f2541180-27ea-439e-941d-165c7dafda67" />

### Alternative:

  - Remove naming pattern enforcement _(making sure it's a zip file)_
      - @Polkas / @gogonzo do you have insights why this is so strict? (source PR: https://github.com/insightsengineering/teal.reporter/pull/251)

https://github.com/insightsengineering/teal.reporter/blob/f776a9e217141b561b1537ca076115d2147d49ea/R/LoadReporterModule.R#L97