### PR TITLE
Update lifecycle badges

### DIFF
--- a/R/AddCardModule.R
+++ b/R/AddCardModule.R
@@ -1,6 +1,6 @@
 #' Add card button module
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Provides a button to add views/cards to a report.
 #'

--- a/R/DownloadModule.R
+++ b/R/DownloadModule.R
@@ -1,6 +1,6 @@
 #' Download report button module
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Provides a button that triggers downloading a report.
 #'

--- a/R/LoadReporterModule.R
+++ b/R/LoadReporterModule.R
@@ -1,6 +1,6 @@
 #' Load `Reporter` button module
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Provides a button to upload `ReporterCard`(s) to the `Reporter`.
 #'

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -113,7 +113,7 @@ preview_report_button_srv <- function(id, reporter) {
 #' @export
 reporter_previewer_ui <- function(id) {
   ns <- shiny::NS(id)
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_stop(
     when = "",
     what = "reporter_previewer_ui()",
     details = paste(

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -328,4 +328,3 @@ block_to_html <- function(b) {
     stop("Unknown block class")
   }
 }
-

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -14,38 +14,6 @@
 #' @return `NULL`.
 NULL
 
-#' Report previewer module
-#'
-#' @description `r lifecycle::badge("deprecated")`
-#'
-#' Module offers functionalities to visualize, manipulate,
-#' and interact with report cards that have been added to a report.
-#' It includes a previewer interface to see the cards and options to modify the report before downloading.
-#'
-#' Cards are saved by the `shiny` bookmarking mechanism.
-#'
-#' For more details see the vignette: `vignette("previewerReporter", "teal.reporter")`.
-#'
-#' This function is deprecated and will be removed in the next release.
-#' Please use `preview_report_button_ui()` and `preview_report_button_srv()`
-#' to create a preview button that opens a modal with the report preview.
-#'
-#' @details `r global_knitr_details()`
-#'
-#' @name reporter_previewer_deprecated
-#'
-#' @param id (`character(1)`) `shiny` module instance id.
-#' @param reporter (`Reporter`) instance.
-#' @param global_knitr (`list`) of `knitr` parameters (passed to `knitr::opts_chunk$set`)
-#'  for customizing the rendering process.
-#' @param previewer_buttons (`character`) set of modules to include with `c("download", "load", "reset")` possible
-#' values and `"download"` is required.
-#' Default `c("download", "load", "reset")`
-#' @inheritParams reporter_download_inputs
-#'
-#' @return `NULL`.
-NULL
-
 #' @rdname reporter_previewer
 #' @export
 preview_report_button_ui <- function(id, label = "Preview Report") {
@@ -109,6 +77,42 @@ preview_report_button_srv <- function(id, reporter) {
     reporter_previewer_content_srv(id = "preview_content", reporter = reporter)
   })
 }
+
+
+# deprecated ------------------------------------------------------------------------------------------------------
+
+
+#' Report previewer module
+#'
+#' @description `r lifecycle::badge("deprecated")`
+#'
+#' Module offers functionalities to visualize, manipulate,
+#' and interact with report cards that have been added to a report.
+#' It includes a previewer interface to see the cards and options to modify the report before downloading.
+#'
+#' Cards are saved by the `shiny` bookmarking mechanism.
+#'
+#' For more details see the vignette: `vignette("previewerReporter", "teal.reporter")`.
+#'
+#' This function is deprecated and will be removed in the next release.
+#' Please use `preview_report_button_ui()` and `preview_report_button_srv()`
+#' to create a preview button that opens a modal with the report preview.
+#'
+#' @details `r global_knitr_details()`
+#'
+#' @name reporter_previewer_deprecated
+#'
+#' @param id (`character(1)`) `shiny` module instance id.
+#' @param reporter (`Reporter`) instance.
+#' @param global_knitr (`list`) of `knitr` parameters (passed to `knitr::opts_chunk$set`)
+#'  for customizing the rendering process.
+#' @param previewer_buttons (`character`) set of modules to include with `c("download", "load", "reset")` possible
+#' values and `"download"` is required.
+#' Default `c("download", "load", "reset")`
+#' @inheritParams reporter_download_inputs
+#'
+#' @return `NULL`.
+NULL
 
 #' @rdname reporter_previewer_deprecated
 #' @export
@@ -198,6 +202,9 @@ reporter_previewer_srv <- function(id,
     reporter_previewer_content_srv("previewer", reporter = reporter)
   })
 }
+
+
+# reporter_previewer_content --------------------------------------------------------------------------------------
 
 #' @keywords internal
 reporter_previewer_content_ui <- function(id) {
@@ -322,28 +329,3 @@ block_to_html <- function(b) {
   }
 }
 
-#' @noRd
-#' @keywords internal
-previewer_collapse_item <- function(idx, card_name, card_blocks) {
-  htmltools::tagAppendChildren(
-    tag = bslib::accordion_panel(
-      title = paste0("Card ", idx, ": ", card_name),
-      shiny::tags$div(
-        id = paste0("card", idx),
-        lapply(
-          card_blocks,
-          function(b) {
-            block_to_html(b)
-          }
-        )
-      )
-    ),
-    .cssSelector = ".accordion-header",
-    shiny::actionButton(
-      inputId = paste0("card_remove_id_", idx),
-      label = "Remove card",
-      class = "card_remove_id",
-      `data-cardid` = idx
-    )
-  )
-}

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -1,7 +1,5 @@
 #' Show report previewer button module
 #'
-#' @description `r lifecycle::badge("experimental")`
-#'
 #' Provides a button that triggers showing the report preview in a modal.
 #'
 #' For more details see the vignette: `vignette("previewerReporter", "teal.reporter")`.

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -119,7 +119,7 @@ NULL
 reporter_previewer_ui <- function(id) {
   ns <- shiny::NS(id)
   lifecycle::deprecate_soft(
-    when = "",
+    when = "0.4.1",
     what = "reporter_previewer_ui()",
     details = paste(
       "Calling `reporter_previewer_ui()` is deprecated and will be removed in the next release.\n",
@@ -155,7 +155,7 @@ reporter_previewer_srv <- function(id,
                                    rmd_yaml_args = getOption("teal.reporter.rmd_yaml_args"),
                                    previewer_buttons = c("download", "load", "reset")) {
   lifecycle::deprecate_soft(
-    when = "",
+    when = "0.4.1",
     what = "reporter_previewer_srv()",
     details = paste(
       "Calling `reporter_previewer_srv()` is deprecated and will be removed in the next release.\n",

--- a/R/Previewer.R
+++ b/R/Previewer.R
@@ -1,5 +1,6 @@
 #' Show report previewer button module
 #'
+#' @description `r lifecycle::badge("experimental")`
 #' Provides a button that triggers showing the report preview in a modal.
 #'
 #' For more details see the vignette: `vignette("previewerReporter", "teal.reporter")`.
@@ -113,7 +114,7 @@ preview_report_button_srv <- function(id, reporter) {
 #' @export
 reporter_previewer_ui <- function(id) {
   ns <- shiny::NS(id)
-  lifecycle::deprecate_stop(
+  lifecycle::deprecate_soft(
     when = "",
     what = "reporter_previewer_ui()",
     details = paste(

--- a/R/ReportCard.R
+++ b/R/ReportCard.R
@@ -1,7 +1,7 @@
 #' @title `ReportCard`: An `R6` class for building report elements
 #' @docType class
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' This `R6` class that supports creating a report card containing text, plot, table and
 #' metadata blocks that can be appended and rendered to form a report output from a `shiny` app.

--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -1,6 +1,6 @@
 #' @title `Reporter`: An `R6` class for managing report cards
 #' @docType class
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' This `R6` class is designed to store and manage report cards,
 #' facilitating the creation, manipulation, and serialization of report-related data.

--- a/R/ResetModule.R
+++ b/R/ResetModule.R
@@ -1,6 +1,6 @@
 #' Reset report button module
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Provides a button that triggers resetting the report content.
 #'

--- a/R/SimpleReporter.R
+++ b/R/SimpleReporter.R
@@ -1,6 +1,6 @@
 #' Simple reporter module
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Module provides compact UI and server functions for managing a report in a `shiny` app.
 #' This module combines functionalities for [adding cards to a report][add_card_button],

--- a/R/teal.reporter.R
+++ b/R/teal.reporter.R
@@ -7,7 +7,6 @@
 
 #' @importFrom checkmate assert_string
 #' @importFrom grid grid.newpage
-#' @importFrom lifecycle badge
 #' @importFrom R6 R6Class
 #' @importFrom rmarkdown render
 #' @importFrom yaml as.yaml

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,5 @@
 #' Panel group widget
 #'
-#' `r lifecycle::badge("experimental")`
 #'
 #' @param title (`character`) title of panel
 #' @param ... content of panel

--- a/R/yaml_utils.R
+++ b/R/yaml_utils.R
@@ -274,8 +274,6 @@ as_yaml_auto <- function(input_list,
 
 #' Print method for the `yaml_header` class
 #'
-#' `r lifecycle::badge("experimental")`
-#'
 #' @param x (`rmd_yaml_header`) class object.
 #' @param ... optional text.
 #' @return `NULL`.

--- a/R/yaml_utils.R
+++ b/R/yaml_utils.R
@@ -85,7 +85,7 @@ conv_str_logi <- function(input,
 
 #' Get document output types from the `rmarkdown` package
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Retrieves vector of available document output types from the `rmarkdown` package,
 #' such as `pdf_document`, `html_document`, etc.
@@ -101,7 +101,7 @@ rmd_outputs <- function() {
 
 #' Get document output arguments from the `rmarkdown` package
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Retrieves the arguments for a specified document output type from the `rmarkdown` package.
 #'
@@ -125,7 +125,7 @@ rmd_output_arguments <- function(output_name, default_values = FALSE) {
 
 #' Parse a named list to `yaml` header for an `Rmd` file
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description
 #'
 #' Converts a named list into a `yaml` header for `Rmd`, handling output types and arguments
 #' as defined in the `rmarkdown` package. This function simplifies the process of generating `yaml` headers.

--- a/man/ReportCard.Rd
+++ b/man/ReportCard.Rd
@@ -5,8 +5,6 @@
 \alias{ReportCard}
 \title{\code{ReportCard}: An \code{R6} class for building report elements}
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 This \code{R6} class that supports creating a report card containing text, plot, table and
 metadata blocks that can be appended and rendered to form a report output from a \code{shiny} app.
 

--- a/man/Reporter.Rd
+++ b/man/Reporter.Rd
@@ -5,8 +5,6 @@
 \alias{Reporter}
 \title{\code{Reporter}: An \code{R6} class for managing report cards}
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 This \code{R6} class is designed to store and manage report cards,
 facilitating the creation, manipulation, and serialization of report-related data.
 }

--- a/man/add_card_button.Rd
+++ b/man/add_card_button.Rd
@@ -23,8 +23,6 @@ add_card_button_srv(id, reporter, card_fun)
 \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Provides a button to add views/cards to a report.
 
 For more details see the vignette: \code{vignette("simpleReporter", "teal.reporter")}.

--- a/man/as_yaml_auto.Rd
+++ b/man/as_yaml_auto.Rd
@@ -29,8 +29,6 @@ if they are recognized as quoted \code{yaml} logical values , default \code{TRUE
 result of \code{\link[yaml:as.yaml]{yaml::as.yaml}}, optionally wrapped with internal \code{md_header()}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Converts a named list into a \code{yaml} header for \code{Rmd}, handling output types and arguments
 as defined in the \code{rmarkdown} package. This function simplifies the process of generating \code{yaml} headers.
 }

--- a/man/download_report_button.Rd
+++ b/man/download_report_button.Rd
@@ -40,8 +40,6 @@ The default value for \code{"output"} has to be in the \code{rmd_output} argumen
 \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Provides a button that triggers downloading a report.
 
 For more information, refer to the vignette: \code{vignette("simpleReporter", "teal.reporter")}.

--- a/man/load_report_button.Rd
+++ b/man/load_report_button.Rd
@@ -23,8 +23,6 @@ report_load_srv(id, reporter)
 \code{shiny::moduleServer}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Provides a button to upload \code{ReporterCard}(s) to the \code{Reporter}.
 
 For more information, refer to the vignette: \code{vignette("simpleReporter", "teal.reporter")}.

--- a/man/panel_item.Rd
+++ b/man/panel_item.Rd
@@ -22,6 +22,6 @@ indicates whether the panel item is open or collapsed and is accessed with \code
 \code{shiny.tag}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Panel group widget
 }
 \keyword{internal}

--- a/man/print.rmd_yaml_header.Rd
+++ b/man/print.rmd_yaml_header.Rd
@@ -15,7 +15,7 @@
 \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Print method for the \code{yaml_header} class
 }
 \examples{
 input <- list(author = "", output = "pdf_document", toc = TRUE, keep_tex = TRUE)

--- a/man/reporter_previewer.Rd
+++ b/man/reporter_previewer.Rd
@@ -21,8 +21,8 @@ preview_report_button_srv(id, reporter)
 \code{NULL}.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Provides a button that triggers showing the report preview in a modal.
-}
-\details{
+
 For more details see the vignette: \code{vignette("previewerReporter", "teal.reporter")}.
 }

--- a/man/reporter_previewer.Rd
+++ b/man/reporter_previewer.Rd
@@ -21,9 +21,8 @@ preview_report_button_srv(id, reporter)
 \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Provides a button that triggers showing the report preview in a modal.
-
+}
+\details{
 For more details see the vignette: \code{vignette("previewerReporter", "teal.reporter")}.
 }

--- a/man/reset_report_button.Rd
+++ b/man/reset_report_button.Rd
@@ -21,8 +21,6 @@ reset_report_button_srv(id, reporter)
 \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Provides a button that triggers resetting the report content.
 
 For more information, refer to the vignette: \code{vignette("simpleReporter", "teal.reporter")}.

--- a/man/rmd_output_arguments.Rd
+++ b/man/rmd_output_arguments.Rd
@@ -12,8 +12,6 @@ rmd_output_arguments(output_name, default_values = FALSE)
 \item{default_values}{(\code{logical(1)}) if to return a default values for each argument.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Retrieves the arguments for a specified document output type from the \code{rmarkdown} package.
 }
 \examples{

--- a/man/rmd_outputs.Rd
+++ b/man/rmd_outputs.Rd
@@ -10,8 +10,6 @@ rmd_outputs()
 \code{character} vector.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Retrieves vector of available document output types from the \code{rmarkdown} package,
 such as \code{pdf_document}, \code{html_document}, etc.
 }

--- a/man/simple_reporter.Rd
+++ b/man/simple_reporter.Rd
@@ -43,8 +43,6 @@ The default value for \code{"output"} has to be in the \code{rmd_output} argumen
 \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Module provides compact UI and server functions for managing a report in a \code{shiny} app.
 This module combines functionalities for \link[=add_card_button]{adding cards to a report},
 \link[=download_report_button]{downloading the report}, and \link[=reset_report_button]{resetting report content}.


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/649

Current version 0.4.0 will be probably bumped to 0.4.1 or higher. Removing all `experimental` badges added at 0.3.1 or before.

Removed `experimental` badges
- added 3 years ago in here   
    - https://github.com/insightsengineering/teal.reporter/pull/61
- in Load reporter added over a year ago in version 0.3.1
    - https://github.com/insightsengineering/teal.reporter/pull/251
- in `panel_item` added over a year ago in version 0.3.0
    - https://github.com/insightsengineering/teal.reporter/pull/247

Changed `deprecated_soft` to `depreacated_stop`
- `reporter_previewer_deprecated` (added 3 years ago in https://github.com/insightsengineering/teal.reporter/pull/61)