### PR TITLE
Use basename in `.content_to_rmd` for Windows paths

### DIFF
--- a/R/to_rmd.R
+++ b/R/to_rmd.R
@@ -1,5 +1,5 @@
 .content_to_rmd <- function(block, output_dir, ...) {
-  path <- tempfile(pattern = "report_item_", fileext = ".rds", tmpdir = output_dir)
+  path <- basename(tempfile(pattern = "report_item_", fileext = ".rds"))
   suppressWarnings(saveRDS(block, file = path))
   sprintf("```{r echo = FALSE, eval = TRUE}\nreadRDS('%s')\n```", path)
 }


### PR DESCRIPTION
Previously, this was the path that ended up in the Rmarkdown file


<img width="966" height="913" alt="image (3)" src="https://github.com/user-attachments/assets/11c6d7b8-553e-4fe3-932a-7e4c5258ad11" />

that triggered inability to render the report for Windows

```r
Quitting from report.Rmd:41-43 [unnamed-chunk-4]
Render document error: Error in `gzfile()`:
! cannot open the connection
```

The root cause is `tempfile` in `.content_to_rmd`

```r
sprintf("```{r echo = FALSE, eval = TRUE}\nreadRDS('%s')\n```", tempfile(pattern = "report_item_", fileext = ".rds", tmpdir = "."))
[1] "```{r echo = FALSE, eval = TRUE}\nreadRDS('.\\report_item_1c5031484b54.rds')\n```"
tempfile(pattern = "report_item_", fileext = ".rds", tmpdir = ".")
[1] ".\\report_item_1c503c7536c0.rds"
```

The solution is to take the `basename()` to curate the name of the file on windows

```r
sprintf("```{r echo = FALSE, eval = TRUE}\nreadRDS('%s')\n```", basename(tempfile(pattern = "report_item_", fileext = ".rds", tmpdir = ".")))
[1] "```{r echo = FALSE, eval = TRUE}\nreadRDS('report_item_1c50c277fb2.rds')\n```"
```


