### PR TITLE
Extend `shinyjs` to allow title edits in reporter previewer

### DIFF
--- a/R/previewer_report.R
+++ b/R/previewer_report.R
@@ -56,6 +56,7 @@ preview_report_button_srv <- function(id, reporter) {
       shiny::tags$div(
         class = "teal-reporter reporter-previewer-modal",
         .custom_css_dependency(),
+        shinyjs::extendShinyjs(text = "", functions = c("jumpToFocus", "enterToSubmit", "autoFocusModal")),
         shiny::modalDialog(
           easyClose = TRUE,
           size = "xl",


### PR DESCRIPTION
Fix #386