### PR TITLE
Allows same card being added multiple times to reporter

### DIFF
--- a/R/Reporter.R
+++ b/R/Reporter.R
@@ -188,7 +188,7 @@ Reporter <- R6::R6Class( # nolint: object_name_linter.
       cards <- self$get_cards()
       blocks <- teal_card()
       for (idx in seq_along(cards)) {
-        card <- cards[[idx]]
+        card <- unname(cards[[idx]]) # unname to avoid names conflict in c()
         title <- trimws(metadata(card, "title"))
         metadata(card)$title <- NULL
         card_title <- if (length(title) > 0 && nzchar(title)) {

--- a/R/download.R
+++ b/R/download.R
@@ -259,16 +259,7 @@ reporter_download_inputs <- function(rmd_yaml_args, rmd_output, showrcode, sessi
 #' @noRd
 #' @keywords internal
 any_rcode_block <- function(reporter) {
-  cards <- reporter$get_cards()
-
-  any(
-    vapply(
-      reporter$get_blocks(),
-      inherits,
-      logical(1),
-      what = "code_chunk"
-    )
-  )
+  any(vapply(reporter$get_blocks(), inherits, logical(1), what = "code_chunk"))
 }
 
 .report_identifier <- function(reporter) {

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -116,7 +116,6 @@ teal_card.qenv <- function(...) {
 #' @export
 as.teal_card <- function(x) { # nolint: object_name.
   if (inherits(x, "teal_card")) {
-    # browser()
     if (length(x) && !checkmate::test_names(names(x), type = "unique")) { # Fix names if not unique or missing
       names(x) <- substr(
         vapply(seq_len(length(x)), function(ix) rlang::hash(list(ix, Sys.time(), x[[ix]])), character(1L)),

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -116,6 +116,14 @@ teal_card.qenv <- function(...) {
 #' @export
 as.teal_card <- function(x) { # nolint: object_name.
   if (inherits(x, "teal_card")) {
+    # browser()
+    if (length(x) && !checkmate::test_names(names(x), type = "unique")) { # Fix names if not unique or missing
+      names(x) <- substr(
+        vapply(seq_len(length(x)), function(ix) rlang::hash(list(ix, Sys.time(), x[[ix]])), character(1L)),
+        1,
+        8
+      )
+    }
     return(x)
   }
   if (identical(class(x), "list")) {

--- a/tests/testthat/test-Reporter.R
+++ b/tests/testthat/test-Reporter.R
@@ -101,6 +101,17 @@ testthat::test_that("get_blocks and get_cards return empty teal_card by default"
   testthat::expect_identical(reporter$get_cards(), structure(list(), names = character(0L)))
 })
 
+testthat::test_that("get_blocks shows repeated cards", {
+  card1 <- teal_card("A title")
+  reporter <- test_reporter(card1, card1)
+
+  testthat::expect_identical(
+    reporter$get_blocks(sep = "sep"),
+    teal_card("# _Unnamed Card (1)_", "A title", "sep", "# _Unnamed Card (2)_", "A title"),
+    ignore_attr = "names"
+  )
+})
+
 testthat::test_that("The deep copy constructor copies the content files to new files", {
   testthat::skip_if_not_installed("ggplot2")
   card <- teal_card(ggplot2::ggplot(iris))

--- a/tests/testthat/test-teal_card.R
+++ b/tests/testthat/test-teal_card.R
@@ -207,6 +207,27 @@ testthat::describe("as.teal_card", {
     doc <- as.teal_card(plot)
     testthat::expect_equal(doc, teal_card(plot), ignore_attr = "names")
   })
+
+  it("corrects names if they do not exist", {
+    simple_list <- list("a", "b", "c")
+    doc <- as.teal_card(simple_list)
+    testthat::expect_equal(unname(doc), structure(list("a", "b", "c"), class = "teal_card"))
+    checkmate::expect_names(names(doc), type = "unique")
+  })
+
+  it("corrects names if they have duplicates", {
+    simple_list <- list(a = "a", b = "b", "c")
+    doc <- as.teal_card(simple_list)
+    testthat::expect_equal(unname(doc), structure(list("a", "b", "c"), class = "teal_card"))
+    checkmate::expect_names(names(doc), type = "unique")
+  })
+
+  it("corrects names if they have duplicates", {
+    simple_list <- list(a = "a", a = "b", c = "c")
+    doc <- as.teal_card(simple_list)
+    testthat::expect_equal(unname(doc), structure(list("a", "b", "c"), class = "teal_card"))
+    checkmate::expect_names(names(doc), type = "unique")
+  })
 })
 
 testthat::describe("metadata", {


### PR DESCRIPTION
# Pull Request

- Fixes #404

### Changes description

- Improve `as.teal_card` to correct for invalid names (non-existing and when non-unique)
- Unname the `teal_card` as it's being added to `Reporter$get_blocks` to avoid conflicts
