### PR TITLE
bring back grob print to report

### DIFF
--- a/R/to_rmd.R
+++ b/R/to_rmd.R
@@ -8,8 +8,15 @@
   path <- basename(tempfile(pattern = "report_item_", fileext = ".rds"))
   suppressWarnings(saveRDS(block, file = path))
   dims <- resolve_figure_dimensions(block, convert_to_inches = TRUE)
+
+  chunk <- if(inherits(block, "grob")) {
+    "```{r echo = FALSE, eval = TRUE, fig.width = %f, fig.height = %f}\nplot <- readRDS('%s')\ngrid::grid.newpage()\ngrid::grid.draw(plot)\n```" #nolint line_length_linter.
+  } else {
+    "```{r echo = FALSE, eval = TRUE, fig.width = %f, fig.height = %f}\nreadRDS('%s')\n```"
+  }
+
   sprintf(
-    "```{r echo = FALSE, eval = TRUE, fig.width = %f, fig.height = %f}\nreadRDS('%s')\n```",
+    chunk,
     dims$width,
     dims$height,
     path


### PR DESCRIPTION
Discovered in here 
https://github.com/insightsengineering/teal.modules.general/pull/917#pullrequestreview-3303377752

After the fix
<img width="793" height="490" alt="image" src="https://github.com/user-attachments/assets/0af5c8fb-d4f9-4ed9-99b8-53d0f7c08cac" />
