### PR TITLE
Fix previewer badge

### DIFF
--- a/R/previewer_report.R
+++ b/R/previewer_report.R
@@ -48,7 +48,7 @@ preview_report_button_srv <- function(id, reporter) {
 
     output$preview_button_counter <- shiny::renderUI({
       shiny::tags$span(
-        class = "position-absolute badge rounded-pill bg-primary",
+        class = "badge rounded-pill bg-primary",
         length(reporter$get_cards())
       )
     })

--- a/inst/css/outline_button.css
+++ b/inst/css/outline_button.css
@@ -1,4 +1,5 @@
 .teal-reporter.outline-button {
+  position: relative;
   padding: 0.3em;
   border-radius: 5px;
   background: transparent;
@@ -29,7 +30,9 @@
 }
 
 .teal-reporter.outline-button .badge {
-  margin-top: 1em;
+  position: absolute;
+  top: -1em;
+  right: -0.5em;
 }
 
 .teal-reporter.outline-button.secondary {


### PR DESCRIPTION
On `@main` badge in "Preview Report" button is wrongly positioned. Because "Preview Report" button has no `position: relative`, badge with `position: absolute` "escapes" the button. 

| Now | Before |
| -----|--------|
| <img width="489" height="199" alt="Skärmavbild 2025-10-16 kl  09 36 05" src="https://github.com/user-attachments/assets/9920ea97-94ec-406d-ad12-9191ab2be861" /> | <img width="484" height="211" alt="Skärmavbild 2025-10-16 kl  09 37 37" src="https://github.com/user-attachments/assets/d6b91d26-6d7b-4990-9add-78687d996619" />
 |


