### PR TITLE
Fix Integration tests

### DIFF
--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -178,12 +178,7 @@ testthat::describe("render() renders output based on metadata$output field:", {
     lines <- base::readLines("report.md", warn = FALSE)
 
     # Pandoc >= 2.11.2 uses ATX headers (# header), older versions use Setext (header\n===)
-    pandoc_ver <- tryCatch(
-      utils::compareVersion(rmarkdown::pandoc_version(), "2.11.2") >= 0,
-      error = function(e) FALSE
-    )
-
-    if (pandoc_ver) {
+    if (rmarkdown::pandoc_available("2.11.2")) {
       # Pandoc >= 2.11.2: Expect ATX style headers
       expected_lines <- c(
         "# test heading",


### PR DESCRIPTION
Fixes 

- https://github.com/insightsengineering/coredev-tasks/issues/673

One of the tests fail due to the old version of pandoc in the non-validated environment.

```
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-render.R:179:5'): render() renders output based on metadata$output field:: - md_document containing markdown content, code chunks and their outputs ──
  `lines` (`actual`) not identical to c(...) (`expected`).
  
  `actual[1:5]`:   "test heading"   "============" "" "Lorem ipsum" ""
  `expected[1:4]`: "# test heading"                "" "Lorem ipsum" ""
  
  [ FAIL 1 | WARN 1 | SKIP 2 | PASS 366 ]
  Error: Test failures
  Execution halted
* DONE

```

Extended tests so they take care of the version of pandoc, which formats headers differently based on the version.
Change in pandoc released in https://pandoc.org/releases.html#pandoc-2.11.2-2020-11-19
also reported in 2020-10 in rmarkdown https://github.com/rstudio/rmarkdown/issues/1956