### PR TITLE
Fixes `teal_card<-` assignment with qenv.error to do nothing instead of throwing error

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
   object_usage_linter = NULL,
-  indentation_linter = NULL
+  indentation_linter = NULL,
+  pipe_consistency_linter = NULL
   )

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -101,6 +101,9 @@ teal_card.qenv <- function(...) {
 #' @param value (`teal_card`) object to set in the `teal_report`.
 #' @export
 `teal_card<-` <- function(x, value) {
+  if (inherits(x, "qenv.error")) { # qenv.error does nothing
+    return (x)
+  }
   x <- methods::as(x, "teal_report")
   checkmate::assert_class(x, "teal_report")
   x@teal_card <- as.teal_card(value)

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -102,7 +102,7 @@ teal_card.qenv <- function(...) {
 #' @export
 `teal_card<-` <- function(x, value) {
   if (inherits(x, "qenv.error")) { # qenv.error does nothing
-    return (x)
+    return(x)
   }
   x <- methods::as(x, "teal_report")
   checkmate::assert_class(x, "teal_report")

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -134,7 +134,7 @@ as.teal_card <- function(x) { # nolint: object_name.
   if (inherits(x, "teal_card")) {
     if (length(x) && !checkmate::test_names(names(x), type = "unique")) { # Fix names if not unique or missing
       names(x) <- substr(
-        vapply(seq_len(length(x)), function(ix) rlang::hash(list(ix, Sys.time(), x[[ix]])), character(1L)),
+        vapply(seq_along(x), function(ix) rlang::hash(list(ix, Sys.time(), x[[ix]])), character(1L)),
         1,
         8
       )

--- a/tests/testthat/test-teal_report-class.R
+++ b/tests/testthat/test-teal_report-class.R
@@ -71,7 +71,7 @@ testthat::test_that("teal_data converts to teal_report when assigning teal_card"
   testthat::expect_s4_class(td, "teal_report")
 })
 
-testthat::test_that("teal_card assignment of qenv.error does nothing and re", {
+testthat::test_that("teal_card assignment of qenv.error does nothing and returns qenv.error", {
   td_original <- within(teal_report(), stop("An error"))
   td <- td_original
   teal_card(td) <- teal_card("# A title")

--- a/tests/testthat/test-teal_report-class.R
+++ b/tests/testthat/test-teal_report-class.R
@@ -70,3 +70,12 @@ testthat::test_that("teal_data converts to teal_report when assigning teal_card"
 
   testthat::expect_s4_class(td, "teal_report")
 })
+
+testthat::test_that("teal_card assignment of qenv.error does nothing and re", {
+  td_original <- within(teal_report(), stop("An error"))
+  td <- td_original
+  teal_card(td) <- teal_card("# A title")
+
+  testthat::expect_s3_class(td, "qenv.error")
+  testthat::expect_identical(td, td_original)
+})


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

- Part of https://github.com/insightsengineering/teal.modules.clinical/issues/1440
- Companion to https://github.com/insightsengineering/teal.modules.clinical/pull/1441 that fixes bug

### Changes description

- Add `teal_card` assignment support
- Test new funcitionality