### PR TITLE
Suppress `c.teal_card` warning when joining `teal_report` objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.reporter 0.6.0.9001
 
+### Miscellaneous
+
+* Prevents warning message when joining two `teal_card` objects that have items with the same id (#455).
+
 # teal.reporter 0.6.0
 
 ### New features

--- a/R/teal_card.R
+++ b/R/teal_card.R
@@ -162,8 +162,11 @@ c.teal_card <- function(...) {
             v
           } else {
             warning(
-              "Appended `teal_card` doesn't remove some of the elements from previous `teal_card`.\n",
-              "Restoring original content and adding only new items to the end of the card."
+              warningCondition(
+                "Appended `teal_card` doesn't remove some of the elements from previous `teal_card`.\n",
+                "Restoring original content and adding only new items to the end of the card.",
+                class = "teal_card_append"
+              )
             )
             utils::modifyList(u, v)
           }

--- a/R/teal_report-c.R
+++ b/R/teal_report-c.R
@@ -10,7 +10,7 @@ c.teal_report <- function(...) {
   result <- NextMethod()
   l <- Filter(function(x) inherits(x, "teal_report"), list(...))
   if (length(l) > 1) {
-    teal_card(result) <- suppressWarnings(do.call(c, lapply(l, teal_card)), class = "teal_card_append")
+    teal_card(result) <- suppressWarnings(do.call(c, lapply(l, teal_card)), classes = "teal_card_append")
   }
   result
 }

--- a/R/teal_report-c.R
+++ b/R/teal_report-c.R
@@ -10,7 +10,7 @@ c.teal_report <- function(...) {
   result <- NextMethod()
   l <- Filter(function(x) inherits(x, "teal_report"), list(...))
   if (length(l) > 1) {
-    teal_card(result) <- do.call(c, lapply(l, teal_card))
+    teal_card(result) <- suppressWarnings(do.call(c, lapply(l, teal_card)), class = "teal_card_append")
   }
   result
 }


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes warning popping up on modules using `c.teal_card` indirectly

```r
pkgload::load_all("/home/averissimo/work/roche🟦/packages📦/teal.reporter")

q1 <- teal.reporter::teal_report() |> within(1+1)
q2 <- within(q1, 2+2)
q3 <- within(q1, 3+3)
c(q2, q3)
#> Warning message:
#> Appended `teal_card` doesn't remove some of the elements from previous `teal_card`.
#>  
#> ✅︎ code verified
#> <environment: 0x5b5d075c6b10> 🔒 
#> Parent: <environment: package:teal.reporter> 
```

### Changes Description

- Adds class to warning condition
  - Allows developers to suppress it explicitly, without hiding other warnings
- Warning should not be presented when merging `teal_report` objects
  - Makes it look as there is something wrong with the operation and on teal apps (such as `tm_g_distribution`)
