### PR TITLE
Empty title knitr warnings removed from tests

### DIFF
--- a/R/to_rmd.R
+++ b/R/to_rmd.R
@@ -110,6 +110,9 @@ to_rmd.default <- function(block, ...) {
 #' @keywords internal
 .to_rmd.teal_card <- function(block, global_knitr = getOption("teal.reporter.global_knitr"), ...) {
   checkmate::assert_subset(names(global_knitr), names(knitr::opts_chunk$get()))
+  if (is.null(metadata(block, "title")) || identical(trimws(metadata(block, "title")), "")) {
+    metadata(block, "title") <- "Report" # enforce a default title
+    }
   is_powerpoint <- identical(metadata(block)$output, "powerpoint_presentation")
   powerpoint_exception_parsed <- if (is_powerpoint) {
     format_code_block_function <- quote(

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -5,6 +5,9 @@ with_temp_wd <- function() {
   withr::defer(setwd(old_dir), envir = parent.frame(2))
 }
 
+# Default title set to prevent warnings in test suite
+default_title_str <- c("---", "title: Report", "---", "", "")
+
 testthat::describe("render() accepts", {
   with_temp_wd()
   it("empty teal_report object", {
@@ -44,6 +47,7 @@ testthat::describe("render() by default", {
     testthat::expect_identical(
       lines,
       c(
+        default_title_str,
         "```{R, include=FALSE}",
         sprintf(
           "knitr::opts_chunk$set(list(echo = TRUE, tidy.opts = list(width.cutoff = 60), tidy = %s))",
@@ -70,7 +74,13 @@ testthat::describe("render() outputs report.Rmd with", {
     teal_card(tr) <- c(teal_card(tr), "# test heading", "Lorem ipsum")
     teal.reporter::render(tr, quiet = TRUE)
     lines <- base::readLines("report.Rmd", warn = FALSE)
-    testthat::expect_identical(lines, c("# test heading", "", "Lorem ipsum"))
+    testthat::expect_identical(
+      lines,
+      c(default_title_str,
+        "# test heading",
+        "",
+        "Lorem ipsum")
+      )
   })
 
   it("yaml header containing entries set through metadata", {
@@ -103,7 +113,7 @@ testthat::describe("render() outputs report.Rmd with", {
     lines <- base::readLines("report.Rmd", warn = FALSE)
     testthat::expect_identical(
       lines,
-      c(
+      c(default_title_str,
         "```{R, include=FALSE}",
         "knitr::opts_chunk$set(list(eval = TRUE, echo = FALSE))",
         "```",
@@ -122,6 +132,7 @@ testthat::describe("render() outputs report.Rmd with", {
     testthat::expect_identical(
       lines,
       c(
+        default_title_str,
         "```{R, include=FALSE}",
         "knitr::opts_chunk$set(list(echo = TRUE, eval = TRUE))",
         "```",
@@ -140,6 +151,7 @@ testthat::describe("render() outputs report.Rmd with", {
     testthat::expect_identical(
       lines,
       c(
+        default_title_str,
         "# test heading",
         "",
         "```{R, eval=FALSE, echo=FALSE}",
@@ -149,7 +161,7 @@ testthat::describe("render() outputs report.Rmd with", {
     )
   })
 
-  it("arbitrary code cunk but chunk_output is missing", {
+  it("arbitrary code chunk but chunk_output is missing", {
     with_temp_wd()
     tr <- teal_report()
     tr <- teal.code::eval_code(tr, "plot(1:10)")
@@ -158,6 +170,7 @@ testthat::describe("render() outputs report.Rmd with", {
     testthat::expect_identical(
       lines,
       c(
+        default_title_str,
         "```{R}",
         "plot(1:10)",
         "```"

--- a/tests/testthat/test-to_rmd.R
+++ b/tests/testthat/test-to_rmd.R
@@ -30,7 +30,7 @@ testthat::describe("to_rmd default support: ", {
     result <- to_rmd(card)
     testthat::expect_match(
       result,
-      "^```[{][rR].*[}].*.*knitr::opts_chunk[$]set.*```[ \n]*"
+      "```[{][rR].*[}].*.*knitr::opts_chunk[$]set.*```[ \n]*"
     )
   })
 


### PR DESCRIPTION
# Pull Request

Fix #447 
Adopted recommended solution of providing a default title if none is present.
Tests no longer return knitr text:
"[WARNING] This document format requires a nonempty <title> element.
 Defaulting to 'report.knit' as the title.
 To specify a title, use 'title' in metadata or --metadata title="..."."

Results from `test_file('tests/testthat/test-render.R')` and `test_file('tests/testthat/test-to_rmd.R')`
<img width="547" height="211" alt="image" src="https://github.com/user-attachments/assets/d95f39e5-1337-48ac-9985-169cd972c8b9" />

